### PR TITLE
fix: ensure web components entry imports button definition

### DIFF
--- a/src/web-components/AGENTS.md
+++ b/src/web-components/AGENTS.md
@@ -8,3 +8,4 @@ This directory extends the repository and `src/components/` guidance for custom 
 
 ## Functional Changes
 - 2024-07-08: Registered the `<fivra-button>` custom element that mirrors the shared Button styles and attributes.
+- 2024-07-09: Ensured `defineDesignSystemElements` explicitly imports `defineFivraButton` to support isolated DTS builds.

--- a/src/web-components/index.ts
+++ b/src/web-components/index.ts
@@ -1,3 +1,5 @@
+import { defineFivraButton } from './button';
+
 export { FivraButtonElement, defineFivraButton } from './button';
 
 export function defineDesignSystemElements(): void {


### PR DESCRIPTION
## Summary
- explicitly import `defineFivraButton` in the web components entry so `defineDesignSystemElements` can call it during isolated builds
- record the web component entrypoint fix in the directory change log

## Testing
- yarn build *(fails: missing `icons.generated` artifacts required for the bundle)*

------
https://chatgpt.com/codex/tasks/task_e_68d997c1ddb8832cab7c50f483d8d6a5