### PR TITLE
Fix Storybook docs glob

### DIFF
--- a/.storybook/AGENTS.md
+++ b/.storybook/AGENTS.md
@@ -16,3 +16,6 @@ This document augments the repository root `AGENTS.md`. Review root conventions 
 - Ensure `yarn storybook`, `yarn build-storybook`, and TypeScript type checks succeed after modifying configuration.
 - Avoid introducing duplicated configuration files or unused legacy settings.
 - Coordinate with component authors if configuration changes require story updates or new documentation.
+
+## Functional Changes
+- 2025-09-28: Updated Storybook story globs to read MDX documentation from `docs/` so overview and integration pages render.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -14,9 +14,9 @@ const resolveAliasPath = (relativePath: string) =>
 
 const config: StorybookConfig = {
   stories: [
-    "../src/docs/**/*.mdx",
+    "../docs/**/*.mdx",
     "../src/components/**/*.stories.@(js|jsx|mjs|ts|tsx)",
-    "../src/docs/**/*.stories.@(js|jsx|mjs|ts|tsx)",
+    "../docs/**/*.stories.@(js|jsx|mjs|ts|tsx)",
   ],
   addons: [
     "@storybook/addon-docs",

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -19,3 +19,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 
 ## Functional Changes
 - 2025-09-25: Documented the new Button component, including React usage and custom element registration steps.
+- 2025-09-28: Ensured Storybook pulls overview and integration MDX pages from `docs/` for sidebar visibility.


### PR DESCRIPTION
## Summary
- point Storybook MDX and story globs at the docs directory so existing pages load
- capture the configuration update in the Storybook and docs AGENTS change logs

## Testing
- yarn storybook -- --smoke-test --quiet *(fails: missing xdg-open in container)*
- yarn build-storybook --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d9a3195f28832c9eed0e4dc4d1217d