### PR TITLE
docs: add tokens governance documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,4 +27,5 @@
 
 ## Functional Changes
 - 2025-09-25: Introduced the Button component with shared React and web component implementations plus associated documentation.
+- 2025-10-08: Established tokens governance in `src/tokens/` (see the new `AGENTS.md` and README) and verified repository health with `yarn test` and `yarn build`.
 

--- a/src/tokens/AGENTS.md
+++ b/src/tokens/AGENTS.md
@@ -1,0 +1,16 @@
+# Tokens Directory Guidelines
+
+This document inherits all policies from the repository root `AGENTS.md`. Review those standards before working within `src/tokens/`.
+
+## Design Token Exports
+- Tokens Studio exports are stored verbatim in this directory. `$themes.json` aggregates theme metadata, while the `Internals/` folder contains source token collections (currently `Engage.json` and `Legacy.json`).
+- `Internals/Engage.json` tracks the actively maintained Engage theme. `Internals/Legacy.json` preserves the historical baseline for migration references.
+- Additional exports (for example, future `Externals/` packages) must document their purpose in this README and mirror the naming conventions established by Tokens Studio.
+
+## Maintenance Expectations
+- Keep the README in this directory updated whenever token hierarchies, theme naming, or export workflows change.
+- Preserve file integrity for downstream automation: do not manually edit JSON exports—refresh them directly from Tokens Studio and note the update in the change log below.
+- Coordinate with the Style Dictionary pipeline when introducing new token categories so preprocessing assumptions remain valid.
+
+## Functional Changes
+- 2025-10-08: Established directory governance, documented Engage/Legacy exports, and recorded the initial Tokens Studio import; validated with `yarn test` and `yarn build`.

--- a/src/tokens/README.md
+++ b/src/tokens/README.md
@@ -1,0 +1,21 @@
+# Tokens Overview
+
+This directory stores raw exports from Tokens Studio that feed the Style Dictionary build pipeline. The exports are organized as follows:
+
+- `$themes.json`: Master theme manifest produced by Tokens Studio. It maps semantic theme names (for example, Engage and Legacy) to token sets and metadata consumed by downstream tooling.
+- `Internals/Engage.json`: Source tokens for the Engage theme. These values represent the actively supported design language for new product work.
+- `Internals/Legacy.json`: Source tokens for the Legacy theme. They provide compatibility for products that have not migrated to Engage yet.
+- `Externals/`: Reserved for vendor-facing or shared exports that mirror the Tokens Studio structure. Populate this directory only when those token groups are introduced upstream.
+
+## Refreshing Exports from Tokens Studio
+1. Open the Fivra workspace in Tokens Studio and ensure the Engage and Legacy token sets are up to date.
+2. Use the "Export" workflow to generate JSON outputs for `$themes.json` and each token set under `Internals/` (and `Externals/` when applicable).
+3. Replace the corresponding files in this directory with the newly exported JSON files. Avoid manual edits so checksums remain trustworthy for automation.
+4. Update this README and the local `AGENTS.md` if the export structure (file names, folder organization, or theme coverage) changes.
+5. Record the refresh in the `Functional Changes` log inside `src/tokens/AGENTS.md`, including a summary of what changed and any validation performed.
+
+## Style Dictionary Preprocessing Assumptions
+- The build expects the Engage and Legacy themes to be declared in `$themes.json` with keys matching the file names inside `Internals/`.
+- Tokens are stored in raw Tokens Studio format. Style Dictionary scripts handle normalization, naming conversions, and platform-specific transforms during the build.
+- New token categories should use the same naming conventions (PascalCase groupings with slash-delimited paths) so the preprocessing scripts can infer semantic groupings without additional configuration.
+- Any new themes or token sets must be added to the Style Dictionary configuration before running `yarn build`, otherwise the pipeline will omit them.


### PR DESCRIPTION
## Summary
- add a tokens directory AGENTS that inherits the root policies and explains the Engage/Legacy export layout
- document how to refresh Tokens Studio exports and capture Style Dictionary assumptions in `src/tokens/README.md`
- note the new tokens governance in the repository-wide change log

## Testing
- `yarn test`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_e_68d9a886f20c832c93525d3321f86985