### PR TITLE
Align AGENTS change logs with semantic version guidance

### DIFF
--- a/.storybook/AGENTS.md
+++ b/.storybook/AGENTS.md
@@ -18,4 +18,5 @@ This document augments the repository root `AGENTS.md`. Review root conventions 
 - Coordinate with component authors if configuration changes require story updates or new documentation.
 
 ## Functional Changes
-- 2025-09-25: Updated Storybook story globs to read MDX documentation from `docs/` so overview and integration pages render.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Updated Storybook story globs to read MDX documentation from `docs/` so overview and integration pages render.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,8 +27,9 @@
 - When implementing features that alter technology choices, architectural boundaries, integration contracts, or documented component behavior, update the corresponding documents alongside your code changes.
 
 ## Functional Changes
-- 2025-09-25: Introduced the Button component with shared React and web component implementations plus associated documentation.
-- 2025-09-25: Established tokens governance in `src/tokens/` (see the new `AGENTS.md` and README) and verified repository health with `yarn test` and `yarn build`.
-- 2025-09-25: Added a Style Dictionary + Tokens Studio transform workflow; run `yarn generate:tokens` to refresh theme CSS before builds.
-- 2025-09-25: Scoped generated Engage/Legacy CSS to `data-fivra-theme`, added theme helpers/tests, and wired `yarn generate:tokens` into build + Storybook hooks.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Introduced the Button component with shared React and web component implementations plus associated documentation.
+- 1.0: Established tokens governance in `src/tokens/` (see the new `AGENTS.md` and README) and verified repository health with `yarn test` and `yarn build`.
+- 1.0: Added a Style Dictionary + Tokens Studio transform workflow; run `yarn generate:tokens` to refresh theme CSS before builds.
+- 1.0: Scoped generated Engage/Legacy CSS to `data-fivra-theme`, added theme helpers/tests, and wired `yarn generate:tokens` into build + Storybook hooks.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -18,6 +18,7 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - Cross-link relevant component stories, scripts, and architectural docs to help teams adopt multi-framework patterns.
 
 ## Functional Changes
-- 2025-09-25: Documented the new Button component, including React usage and custom element registration steps.
-- 2025-09-25: Ensured Storybook pulls overview and integration MDX pages from `docs/` for sidebar visibility.
-- 2025-09-25: Documented the theme token workflow, runtime helpers, and data-attribute switching strategy.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Documented the new Button component, including React usage and custom element registration steps.
+- 1.0: Ensured Storybook pulls overview and integration MDX pages from `docs/` for sidebar visibility.
+- 1.0: Documented the theme token workflow, runtime helpers, and data-attribute switching strategy.

--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -7,4 +7,5 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 - Update the "Functional Changes" section below whenever documentation changes to reflect new component behavior.
 
 ## Functional Changes
-- 2025-09-25: Authored the initial Button reference guide covering React and custom element usage.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Authored the initial Button reference guide covering React and custom element usage.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -18,5 +18,6 @@ This file extends the repository root `AGENTS.md`. Always review the root conven
 - Document new or updated commands in `docs/` so teams understand cross-framework workflows.
 
 ## Functional Changes
-- 2025-09-25: Added `generate-design-tokens.mjs` to produce CSS themes and a manifest via Style Dictionary and Tokens Studio transforms.
-- 2025-09-25: Updated `generate-design-tokens.mjs` to build external themes against a single internal source set, emit only public variables, and capture the set pairing in the generated manifest.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Added `generate-design-tokens.mjs` to produce CSS themes and a manifest via Style Dictionary and Tokens Studio transforms.
+- 1.0: Updated `generate-design-tokens.mjs` to build external themes against a single internal source set, emit only public variables, and capture the set pairing in the generated manifest.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -19,5 +19,6 @@ This document extends the root-level `AGENTS.md`. All contributors must read and
 - Update corresponding documentation in `docs/` and stories under `src/stories/` when component APIs or visuals shift.
 
 ## Functional Changes
-- 2025-09-25: Added the shared Button implementation (React + web component) with reusable styling primitives.
-- 2025-10-02: Button and Icon now consume theme tokens for layout, color, and state styling; Storybook docs updated accordingly.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Added the shared Button implementation (React + web component) with reusable styling primitives.
+- 1.0: Button and Icon now consume theme tokens for layout, color, and state styling; Storybook docs updated accordingly.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -7,5 +7,6 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - Update the "Functional Changes" section below with a short note when behavior or public API changes.
 
 ## Functional Changes
-- 2025-09-25: Initial `Button` component authored as both a React component and custom element with shared styling.
-- 2025-10-02: Button styling variables now map directly to Engage/Legacy design tokens (backgrounds, states, spacing, radii, icon sizes).
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Initial `Button` component authored as both a React component and custom element with shared styling.
+- 1.0: Button styling variables now map directly to Engage/Legacy design tokens (backgrounds, states, spacing, radii, icon sizes).

--- a/src/stories/AGENTS.md
+++ b/src/stories/AGENTS.md
@@ -18,4 +18,5 @@ This guide supplements the repository root `AGENTS.md`. Review the root standard
 - Validate stories in all supported frameworks before merging.
 
 ## Functional Changes
-- 2025-09-25: Added Button stories covering React usage, variants, sizes, icons, and responsive layouts.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Added Button stories covering React usage, variants, sizes, icons, and responsive layouts.

--- a/src/styles/AGENTS.md
+++ b/src/styles/AGENTS.md
@@ -7,4 +7,5 @@ This file inherits the repository root `AGENTS.md`. Generated theme assets live 
 - Run `yarn generate:tokens` after updating any design token exports to refresh these files before committing.
 
 ## Functional Changes
-- 2025-09-25: Added layered `index.css`, theme helpers, and scoped CSS selectors so `data-fivra-theme` toggles Engage/Legacy tokens.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Added layered `index.css`, theme helpers, and scoped CSS selectors so `data-fivra-theme` toggles Engage/Legacy tokens.

--- a/src/tokens/AGENTS.md
+++ b/src/tokens/AGENTS.md
@@ -13,4 +13,5 @@ This document inherits all policies from the repository root `AGENTS.md`. Review
 - Coordinate with the Style Dictionary pipeline when introducing new token categories so preprocessing assumptions remain valid.
 
 ## Functional Changes
-- 2025-09-25: Established directory governance, documented Engage/Legacy exports, and recorded the initial Tokens Studio import; validated with `yarn test` and `yarn build`.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Established directory governance, documented Engage/Legacy exports, and recorded the initial Tokens Studio import; validated with `yarn test` and `yarn build`.

--- a/src/web-components/AGENTS.md
+++ b/src/web-components/AGENTS.md
@@ -7,6 +7,7 @@ This directory extends the repository and `src/components/` guidance for custom 
 - Update the "Functional Changes" log below whenever a web component gains new capabilities.
 
 ## Functional Changes
-- 2025-09-25: Registered the `<fivra-button>` custom element that mirrors the shared Button styles and attributes.
-- 2025-09-25: Ensured `defineDesignSystemElements` explicitly imports `defineFivraButton` to support isolated DTS builds.
-- 2025-10-02: Synced injected button styles with tokenized variables so the custom element reflects theme spacing, colors, and focus states.
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0: Registered the `<fivra-button>` custom element that mirrors the shared Button styles and attributes.
+- 1.0: Ensured `defineDesignSystemElements` explicitly imports `defineFivraButton` to support isolated DTS builds.
+- 1.0: Synced injected button styles with tokenized variables so the custom element reflects theme spacing, colors, and focus states.


### PR DESCRIPTION
## Summary
- replace dated functional change bullets in each AGENTS.md with semantic version 1.0 entries while preserving their descriptions
- document that future functional change entries must use <major>.<minor>[.<patch>] labels instead of dates across all AGENTS guides

## Testing
- rg "2025-" -g 'AGENTS.md'

------
https://chatgpt.com/codex/tasks/task_e_68d9c07b4a84832ca102973d2cf001f0