### PR TITLE
feat: add Storybook theme control

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,6 +1,65 @@
+import React, { useEffect } from 'react';
+import '../src/styles/index.css';
+import {
+  applyDesignTokenTheme,
+  clearDesignTokenTheme,
+  designTokenManifest,
+  getDefaultDesignTokenTheme,
+} from '../src/styles/themes';
+
 /**
  * Global Storybook parameters and decorators for React stories.
  */
+
+const defaultTheme = getDefaultDesignTokenTheme();
+
+export const globalTypes = {
+  theme: {
+    name: 'Theme',
+    description: 'Select the design token theme applied to stories.',
+    defaultValue: defaultTheme.slug,
+    toolbar: {
+      icon: 'paintbrush',
+      dynamicTitle: true,
+      items: designTokenManifest.themes.map((theme) => ({
+        value: theme.slug,
+        title: theme.name,
+      })),
+    },
+  },
+};
+
+const ThemeProvider = ({ slug, children }) => {
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return undefined;
+    }
+
+    applyDesignTokenTheme(document, slug);
+
+    return () => {
+      if (typeof document === 'undefined') {
+        return;
+      }
+
+      clearDesignTokenTheme(document);
+    };
+  }, [slug]);
+
+  return children;
+};
+
+const withDesignTokenTheme = (Story, context) => {
+  const slug = context.globals.theme ?? defaultTheme.slug;
+
+  return React.createElement(
+    ThemeProvider,
+    { slug },
+    React.createElement(Story),
+  );
+};
+
+export const decorators = [withDesignTokenTheme];
 
 /** @type { import('@storybook/react').Preview } */
 export const parameters = {


### PR DESCRIPTION
## Summary
- import the generated design token bundle in Storybook so Engage/Legacy layers register before rendering
- add a theme toolbar control and decorator that applies and clears design token themes based on the selected slug

## Testing
- yarn build
- yarn test
- yarn storybook --smoke-test --ci
- yarn build-storybook

------
https://chatgpt.com/codex/tasks/task_e_68da4fe7b7fc832ca502d86bb8df0661