### PR TITLE
feat: expand button variants and states

### DIFF
--- a/.changeset/tertiary-button-upgrade.md
+++ b/.changeset/tertiary-button-upgrade.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": minor
+---
+
+Add tertiary button variant with icon-only, dropdown, and loading states plus token-aligned spacing.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -24,3 +24,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - 1.0: Ensured Storybook pulls overview and integration MDX pages from `docs/` for sidebar visibility.
 - 1.0: Documented the theme token workflow, runtime helpers, and data-attribute switching strategy.
 - 1.1.0: Added documentation for the Changesets release pipeline, the `yarn changeset` authoring flow, and the AGENTS verification guard.
+- 1.2.0: Updated Button reference materials with tertiary styling, icon-only guidance, and loading/dropdown documentation.

--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -9,3 +9,4 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 ## Functional Changes
 - Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
 - 1.0: Authored the initial Button reference guide covering React and custom element usage.
+- 1.2.0: Documented tertiary styling, icon-only/dropdown/loading APIs, and new token references for the Button component.

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -30,11 +30,15 @@ export function SaveButton() {
 
 | Prop | Type | Default | Description |
 | --- | --- | --- | --- |
-| `variant` | `'primary' \| 'secondary' \| 'ghost'` | `primary` | Chooses the visual treatment: filled, outlined, or subtle. |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary'` | `primary` | Chooses the visual treatment mapped to `--backgroundPrimaryInteractive`, `--backgroundNeutral0`, or a transparent tertiary surface. |
 | `size` | `'sm' \| 'md' \| 'lg'` | `md` | Adjusts typography, padding, and icon spacing. |
 | `fullWidth` | `boolean` | `false` | When `true`, sets the button width to 100% of its container. |
 | `leadingIcon` | `React.ReactNode` | `undefined` | Optional icon rendered before the label with `aria-hidden`. |
 | `trailingIcon` | `React.ReactNode` | `undefined` | Optional icon rendered after the label with `aria-hidden`. |
+| `iconOnly` | `boolean` | `false` | Removes the visible label, switches to `--radiusMax`, and requires an accessible name via `aria-label`/`aria-labelledby`. |
+| `hasLabel` | `boolean` | `undefined` | Overrides automatic label detection when providing off-screen copy or live region text. |
+| `dropdown` | `boolean` | `false` | Appends a disclosure caret to hint at menu/split button behavior. |
+| `loading` | `boolean` | `false` | Displays the centered spinner and sets `aria-busy` on the button. |
 | `...buttonProps` | `React.ButtonHTMLAttributes<HTMLButtonElement>` | – | Native button attributes such as `type`, `disabled`, `aria-pressed`, etc. |
 
 The component defaults `type="button"` to avoid accidental form submissions. Provide `type="submit"` or `type="reset"` when integrating with forms.
@@ -64,7 +68,7 @@ Slots:
 - default slot – button label.
 - `slot="trailing-icon"` – optional trailing visual.
 
-Attributes mirror the React props (`variant`, `size`, `full-width`, `disabled`, `type`). The element forwards `click`, `focus`, and `blur` behaviors to the internal `<button>` for accessibility.
+Attributes mirror the React props (`variant`, `size`, `full-width`, `disabled`, `type`, `icon-only`, `has-label`, `dropdown`, `loading`). The element forwards `click`, `focus`, and `blur` behaviors to the internal `<button>` for accessibility.
 
 ## Accessibility
 
@@ -74,13 +78,13 @@ Attributes mirror the React props (`variant`, `size`, `full-width`, `disabled`, 
 
 ## Theming
 
-Design tokens are surfaced as CSS variables on the button root (e.g., `--fivra-button-primary-bg`). Override them at the component or global level to align with product branding.
+Design tokens are surfaced as CSS variables on the button root (e.g., `--backgroundPrimaryInteractive`, `--backgroundPrimaryDisabled`, `--textPrimaryInteractive`). Override them at the component or global level to align with product branding.
 
 ```css
 .my-theme {
-  --fivra-button-primary-bg: #7c3aed;
-  --fivra-button-primary-bg-hover: #6d28d9;
-  --fivra-button-focus-ring: 0 0 0 4px rgba(124, 58, 237, 0.35);
+  --backgroundPrimaryInteractive: #7c3aed;
+  --backgroundPrimaryDisabled: #cbd5f5;
+  --textPrimaryInteractive: #ffffff;
 }
 ```
 

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -11,3 +11,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.0: Initial `Button` component authored as both a React component and custom element with shared styling.
 - 1.0: Button styling variables now map directly to Engage/Legacy design tokens (backgrounds, states, spacing, radii, icon sizes).
 - 1.2.0: Added the tertiary variant, icon-only/dropdown/loading affordances, and explicit token-aligned spacing across implementations.
+- 1.2.1: Corrected radius scaling, loading-state colors, and the custom element preview to match the updated button contract.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -10,3 +10,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
 - 1.0: Initial `Button` component authored as both a React component and custom element with shared styling.
 - 1.0: Button styling variables now map directly to Engage/Legacy design tokens (backgrounds, states, spacing, radii, icon sizes).
+- 1.2.0: Added the tertiary variant, icon-only/dropdown/loading affordances, and explicit token-aligned spacing across implementations.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -276,7 +276,7 @@ const WebComponentPreview: React.FC = () => {
   }, []);
 
   return (
-    <fivra-button variant="secondary" size="md" dropdown loading>
+    <fivra-button variant="secondary" size="md" dropdown>
       <span slot="leading-icon" aria-hidden="true">
         ★
       </span>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -25,8 +25,9 @@ const meta: Meta<typeof Button> = {
     },
     variant: {
       control: "inline-radio",
-      options: ["primary", "secondary", "ghost"],
-      description: "Visual treatment of the button.",
+      options: ["primary", "secondary", "tertiary"],
+      description:
+        "Visual treatment of the button mapped to `--backgroundPrimaryInteractive`, `--backgroundNeutral0`, and transparent tiers.",
       table: { category: "Appearance" },
     },
     size: {
@@ -40,12 +41,32 @@ const meta: Meta<typeof Button> = {
       description: "Stretches the button to fill its container width.",
       table: { category: "Layout" },
     },
+    iconOnly: {
+      control: "boolean",
+      description: "Removes the visible label and switches to `--radiusMax`. Provide `aria-label` for accessibility.",
+      table: { category: "Appearance" },
+    },
+    hasLabel: {
+      control: "boolean",
+      description: "Override automatic label detection when rendering screen-reader-only copy.",
+      table: { category: "Accessibility" },
+    },
+    dropdown: {
+      control: "boolean",
+      description: "Appends a disclosure caret for menu triggers.",
+      table: { category: "Appearance" },
+    },
+    loading: {
+      control: "boolean",
+      description: "Displays a spinner with `aria-busy` set on the underlying `<button>`.",
+      table: { category: "State" },
+    },
   },
   parameters: {
     docs: {
       description: {
         component:
-          "Accessible button primitive with primary, secondary, and ghost variants. Supports icons, full-width layout, and forwards native button attributes.",
+          "Accessible button primitive with primary, secondary, and tertiary variants mapped directly to the spec token palette. Supports icons, dropdown affordances, loading states, and forwards native button attributes.",
       },
     },
   },
@@ -79,22 +100,53 @@ export const Secondary: Story = {
     docs: {
       description: {
         story:
-          "Secondary button relies on '--borderSecondaryInteractive' and hover states from '--stateBrandHover' for an outlined treatment.",
+          "Secondary buttons pair `--backgroundNeutral0` with `--borderPrimaryInteractive` to deliver a neutral outline that still shares the brand hover tokens.",
       },
     },
   },
 };
 
-export const Ghost: Story = {
+export const Tertiary: Story = {
   args: {
-    children: "Ghost",
-    variant: "ghost",
+    children: "Tertiary",
+    variant: "tertiary",
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Ghost buttons stay transparent until interaction, leaning on '--textPrimaryInteractive' and brand state overlays.",
+          "Tertiary buttons stay transparent until interaction, relying on `--textPrimaryInteractive` and the selected background overlay tokens for hover and press states.",
+      },
+    },
+  },
+};
+
+export const DisabledStates: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "flex",
+        gap: "calc(var(--spacingL) * 1px)",
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      <Button variant="primary" disabled>
+        Primary
+      </Button>
+      <Button variant="secondary" disabled>
+        Secondary
+      </Button>
+      <Button variant="tertiary" disabled>
+        Tertiary
+      </Button>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Disabled states pull from `--backgroundPrimaryDisabled`, `--backgroundSecondaryDisabled`, and `--textPrimaryDisabled` ensuring consistent contrast and borders via `--borderPrimaryDisabled`.",
       },
     },
   },
@@ -144,7 +196,7 @@ export const Sizes: Story = {
     docs: {
       description: {
         story:
-          "Small, medium, and large presets pull padding, gaps, and icon sizes from the spacing and icon tokens.",
+          "Small, medium, and large presets use explicit padding (12×4, 16×8, 24×12) with heights 24/32/40px and radii mapped to `--radiusXs`, `--radiusS`, and `--radiusM`.",
       },
     },
   },
@@ -170,13 +222,61 @@ export const FullWidth: Story = {
   },
 };
 
+export const Dropdown: Story = {
+  args: {
+    children: "Menu",
+    dropdown: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Dropdown mode adds a built-in caret to communicate nested actions while still supporting manual icon slots if needed.",
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    children: "Saving...",
+    loading: true,
+    disabled: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Setting `loading` renders the centered spinner, sets `aria-busy`, and works alongside `disabled` to block duplicate submissions.",
+      },
+    },
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    iconOnly: true,
+    'aria-label': 'Next',
+    leadingIcon: <Icon name="chevron-right" variant="outline" aria-hidden="true" />,
+  },
+  render: (args) => <Button {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Icon-only buttons collapse to a circular hit area via `--radiusMax`. Remember to supply an accessible `aria-label`.",
+      },
+    },
+  },
+};
+
 const WebComponentPreview: React.FC = () => {
   React.useEffect(() => {
     defineFivraButton();
   }, []);
 
   return (
-    <fivra-button variant="secondary" size="md">
+    <fivra-button variant="secondary" size="md" dropdown loading>
       <span slot="leading-icon" aria-hidden="true">
         ★
       </span>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,6 +6,8 @@ import {
   BUTTON_LABEL_CLASS,
   BUTTON_LEADING_ICON_CLASS,
   BUTTON_TRAILING_ICON_CLASS,
+  BUTTON_SPINNER_CLASS,
+  BUTTON_CARET_CLASS,
   DEFAULT_BUTTON_SIZE,
   DEFAULT_BUTTON_VARIANT,
   type ButtonSize,
@@ -28,6 +30,14 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   leadingIcon?: React.ReactNode;
   /** Optional trailing icon rendered after the label. */
   trailingIcon?: React.ReactNode;
+  /** Hides the visible label for icon-only buttons. Provide an `aria-label`. */
+  iconOnly?: boolean;
+  /** Overrides automatic label detection when rendering a visually hidden label. */
+  hasLabel?: boolean;
+  /** Adds a disclosure caret to the button. */
+  dropdown?: boolean;
+  /** Displays a spinner and marks the button as busy. */
+  loading?: boolean;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
@@ -37,9 +47,15 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props,
     fullWidth = false,
     leadingIcon,
     trailingIcon,
+    iconOnly = false,
+    hasLabel,
+    dropdown = false,
+    loading = false,
     className,
     children,
     type,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
     ...rest
   } = props;
 
@@ -47,6 +63,22 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props,
     ensureButtonStyles();
   }, []);
 
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      iconOnly &&
+      !ariaLabel &&
+      !ariaLabelledBy
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        'Button: iconOnly buttons must include an accessible name via `aria-label` or `aria-labelledby`.',
+      );
+    }
+  }, [ariaLabel, ariaLabelledBy, iconOnly]);
+
+  const resolvedHasLabel =
+    typeof hasLabel === 'boolean' ? hasLabel : Boolean(children) && !iconOnly;
   const buttonType = type ?? 'button';
 
   return (
@@ -58,18 +90,27 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props,
       data-variant={variant}
       data-size={size}
       data-full-width={fullWidth ? 'true' : undefined}
+      data-icon-only={iconOnly ? 'true' : undefined}
+      data-has-label={resolvedHasLabel ? 'true' : 'false'}
+      data-dropdown={dropdown ? 'true' : undefined}
+      data-loading={loading ? 'true' : undefined}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-busy={loading || undefined}
     >
+      {loading ? <span className={BUTTON_SPINNER_CLASS} aria-hidden="true" /> : null}
       {leadingIcon ? (
         <span className={cx(BUTTON_ICON_CLASS, BUTTON_LEADING_ICON_CLASS)} aria-hidden="true">
           {leadingIcon}
         </span>
       ) : null}
-      <span className={BUTTON_LABEL_CLASS}>{children}</span>
+      {resolvedHasLabel ? <span className={BUTTON_LABEL_CLASS}>{children}</span> : null}
       {trailingIcon ? (
         <span className={cx(BUTTON_ICON_CLASS, BUTTON_TRAILING_ICON_CLASS)} aria-hidden="true">
           {trailingIcon}
         </span>
       ) : null}
+      {dropdown ? <span className={BUTTON_CARET_CLASS} aria-hidden="true" /> : null}
     </button>
   );
 });

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -18,14 +18,14 @@ describe('Button', () => {
 
   it('supports variant, size, and fullWidth props', () => {
     render(
-      <Button variant="ghost" size="lg" fullWidth>
+      <Button variant="tertiary" size="lg" fullWidth>
         Explore
       </Button>,
     );
 
     const button = screen.getByRole('button', { name: 'Explore' });
 
-    expect(button).toHaveAttribute('data-variant', 'ghost');
+    expect(button).toHaveAttribute('data-variant', 'tertiary');
     expect(button).toHaveAttribute('data-size', 'lg');
     expect(button).toHaveAttribute('data-full-width', 'true');
   });
@@ -58,5 +58,26 @@ describe('Button', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
 
     expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports iconOnly, dropdown, and loading props', () => {
+    render(
+      <Button
+        iconOnly
+        dropdown
+        loading
+        aria-label="Open menu"
+        leadingIcon={<span data-testid="menu-icon" />}
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Open menu' });
+
+    expect(button).toHaveAttribute('data-icon-only', 'true');
+    expect(button).toHaveAttribute('data-has-label', 'false');
+    expect(button).toHaveAttribute('data-dropdown', 'true');
+    expect(button).toHaveAttribute('data-loading', 'true');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(button.querySelector('.fivra-button__spinner')).toBeInTheDocument();
   });
 });

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -3,11 +3,13 @@ export const BUTTON_ICON_CLASS = `${BUTTON_CLASS_NAME}__icon`;
 export const BUTTON_LABEL_CLASS = `${BUTTON_CLASS_NAME}__label`;
 export const BUTTON_LEADING_ICON_CLASS = `${BUTTON_ICON_CLASS}--leading`;
 export const BUTTON_TRAILING_ICON_CLASS = `${BUTTON_ICON_CLASS}--trailing`;
+export const BUTTON_SPINNER_CLASS = `${BUTTON_CLASS_NAME}__spinner`;
+export const BUTTON_CARET_CLASS = `${BUTTON_CLASS_NAME}__caret`;
 
-export type ButtonVariant = 'primary' | 'secondary' | 'ghost';
+export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';
 export type ButtonSize = 'sm' | 'md' | 'lg';
 
-export const BUTTON_VARIANTS: readonly ButtonVariant[] = ['primary', 'secondary', 'ghost'];
+export const BUTTON_VARIANTS: readonly ButtonVariant[] = ['primary', 'secondary', 'tertiary'];
 export const BUTTON_SIZES: readonly ButtonSize[] = ['sm', 'md', 'lg'];
 
 export const DEFAULT_BUTTON_VARIANT: ButtonVariant = 'primary';
@@ -16,34 +18,32 @@ export const DEFAULT_BUTTON_SIZE: ButtonSize = 'md';
 const BASE_CLASS = `.${BUTTON_CLASS_NAME}`;
 const ICON_CLASS = `.${BUTTON_ICON_CLASS}`;
 const LABEL_CLASS = `.${BUTTON_LABEL_CLASS}`;
+const SPINNER_CLASS = `.${BUTTON_SPINNER_CLASS}`;
+const CARET_CLASS = `.${BUTTON_CARET_CLASS}`;
 
 export const buttonClassStyles = `
 ${BASE_CLASS} {
   --fivra-button-font-family: inherit;
   --fivra-button-font-weight: 600;
-  --fivra-button-radius: var(--radiusMax);
+  --fivra-button-radius: var(--radiusS);
   --fivra-button-transition: background-color 160ms ease, color 160ms ease,
-    box-shadow 160ms ease, border-color 160ms ease;
-  --fivra-button-gap: calc(var(--spacingS) * 1px);
-  --fivra-button-padding-y: calc(var(--spacingS) * 1px);
-  --fivra-button-padding-x: calc(var(--spacingL) * 1px);
+    box-shadow 160ms ease, border-color 160ms ease, opacity 160ms ease;
+  --fivra-button-gap: calc(8 * 1px);
+  --fivra-button-padding-y: calc(8 * 1px);
+  --fivra-button-padding-x: calc(16 * 1px);
   --fivra-button-font-size: 0.95rem;
   --fivra-button-line-height: 1.2;
-  --fivra-button-min-height: calc(var(--spacingXl3) * 1px - var(--spacingS) * 1px);
-  --fivra-button-icon-size: var(--iconsizesL);
-  --fivra-button-primary-bg: var(--backgroundPrimaryInteractive);
-  --fivra-button-primary-bg-hover: var(--stateBrandHover);
-  --fivra-button-primary-bg-active: var(--stateBrandPress);
-  --fivra-button-primary-color: var(--backgroundNeutral0);
-  --fivra-button-secondary-bg: var(--backgroundTertiaryInteractive);
-  --fivra-button-secondary-border: var(--borderSecondaryInteractive);
-  --fivra-button-secondary-border-hover: var(--borderPrimaryInteractive);
-  --fivra-button-secondary-color: var(--textSecondaryInteractive);
-  --fivra-button-secondary-bg-hover: var(--stateBrandHover);
-  --fivra-button-secondary-bg-active: var(--stateBrandPress);
-  --fivra-button-ghost-color: var(--textPrimaryInteractive);
-  --fivra-button-ghost-bg-hover: var(--stateBrandHover);
-  --fivra-button-ghost-bg-active: var(--stateBrandPress);
+  --fivra-button-height: calc(32 * 1px);
+  --fivra-button-icon-size: var(--iconsizesM);
+  --fivra-button-spinner-size: calc(16 * 1px);
+  --fivra-button-bg: var(--backgroundPrimaryInteractive);
+  --fivra-button-bg-hover: var(--stateBrandHover);
+  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-border: var(--borderPrimaryInteractive);
+  --fivra-button-text: var(--backgroundNeutral0);
+  --fivra-button-disabled-bg: var(--backgroundPrimaryDisabled);
+  --fivra-button-disabled-border: var(--borderPrimaryDisabled);
+  --fivra-button-disabled-text: var(--textPrimaryDisabled);
   --fivra-button-focus-ring-width: calc(var(--spacingXs) * 1px);
   --fivra-button-focus-ring-color: var(--stateBrandFocus);
   --fivra-button-shadow: calc(var(--shadowsMX) * 1px) calc(var(--shadowsMY) * 1px)
@@ -53,13 +53,14 @@ ${BASE_CLASS} {
   justify-content: center;
   gap: var(--fivra-button-gap);
   padding: var(--fivra-button-padding-y) var(--fivra-button-padding-x);
-  min-height: var(--fivra-button-min-height);
+  min-height: var(--fivra-button-height);
+  min-width: var(--fivra-button-height);
   border-radius: var(--fivra-button-radius);
   border-width: calc(var(--borderwidthS) * 1px);
   border-style: solid;
-  border-color: transparent;
-  background-color: var(--fivra-button-primary-bg);
-  color: var(--fivra-button-primary-color);
+  border-color: var(--fivra-button-border);
+  background-color: var(--fivra-button-bg);
+  color: var(--fivra-button-text);
   font-family: var(--fivra-button-font-family);
   font-weight: var(--fivra-button-font-weight);
   font-size: var(--fivra-button-font-size);
@@ -79,59 +80,56 @@ ${BASE_CLASS}[data-full-width='true'] {
 }
 
 ${BASE_CLASS}[data-size='sm'] {
-  --fivra-button-padding-y: calc(var(--spacingXs) * 1px + var(--spacingXs2) * 1px);
-  --fivra-button-padding-x: calc(var(--spacingM) * 1px + var(--spacingXs2) * 1px);
+  --fivra-button-padding-y: calc(4 * 1px);
+  --fivra-button-padding-x: calc(12 * 1px);
+  --fivra-button-height: calc(24 * 1px);
+  --fivra-button-radius: var(--radiusXs);
+  --fivra-button-gap: calc(4 * 1px);
+  --fivra-button-icon-size: var(--iconsizesS);
+  --fivra-button-spinner-size: calc(14 * 1px);
   --fivra-button-font-size: 0.85rem;
-  --fivra-button-min-height: calc(var(--spacingXl2) * 1px + var(--spacingXs2) * 1px);
-  --fivra-button-gap: calc(var(--spacingXs) * 1px + var(--spacingXs2) * 1px);
-  --fivra-button-icon-size: var(--iconsizesM);
 }
 
 ${BASE_CLASS}[data-size='lg'] {
-  --fivra-button-padding-y: calc(var(--spacingS) * 1px + var(--spacingXs2) * 1px);
-  --fivra-button-padding-x: calc(var(--spacingL) * 1px + var(--spacingXs) * 1px);
-  --fivra-button-font-size: 1rem;
-  --fivra-button-min-height: calc(var(--spacingXl3) * 1px - var(--spacingXs2) * 1px);
-  --fivra-button-gap: calc(var(--spacingS) * 1px + var(--spacingXs2) * 1px);
+  --fivra-button-padding-y: calc(12 * 1px);
+  --fivra-button-padding-x: calc(24 * 1px);
+  --fivra-button-height: calc(40 * 1px);
+  --fivra-button-radius: var(--radiusM);
+  --fivra-button-gap: calc(12 * 1px);
   --fivra-button-icon-size: var(--iconsizesXl);
+  --fivra-button-spinner-size: calc(20 * 1px);
+  --fivra-button-font-size: 1rem;
 }
 
 ${BASE_CLASS}[data-variant='secondary'] {
-  background-color: var(--fivra-button-secondary-bg);
-  color: var(--fivra-button-secondary-color);
-  border-color: var(--fivra-button-secondary-border);
+  --fivra-button-bg: var(--backgroundNeutral0);
+  --fivra-button-bg-hover: var(--backgroundPrimarySelected);
+  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-border: var(--borderPrimaryInteractive);
+  --fivra-button-text: var(--textPrimaryInteractive);
+  --fivra-button-disabled-bg: var(--backgroundSecondaryDisabled);
+  --fivra-button-disabled-border: var(--borderPrimaryDisabled);
+  --fivra-button-disabled-text: var(--textPrimaryDisabled);
 }
 
-${BASE_CLASS}[data-variant='ghost'] {
-  background-color: transparent;
-  color: var(--fivra-button-ghost-color);
-  border-color: transparent;
+${BASE_CLASS}[data-variant='tertiary'] {
+  --fivra-button-bg: transparent;
+  --fivra-button-bg-hover: var(--backgroundPrimarySelected);
+  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-border: transparent;
+  --fivra-button-text: var(--textPrimaryInteractive);
+  --fivra-button-disabled-bg: transparent;
+  --fivra-button-disabled-border: transparent;
+  --fivra-button-disabled-text: var(--textPrimaryDisabled);
 }
 
-${BASE_CLASS}:hover:not(:disabled) {
-  background-color: var(--fivra-button-primary-bg-hover);
+${BASE_CLASS}:hover:not(:disabled):not([aria-disabled='true']) {
+  background-color: var(--fivra-button-bg-hover);
 }
 
-${BASE_CLASS}[data-variant='secondary']:hover:not(:disabled) {
-  border-color: var(--fivra-button-secondary-border-hover);
-  background-color: var(--fivra-button-secondary-bg-hover);
-}
-
-${BASE_CLASS}[data-variant='ghost']:hover:not(:disabled) {
-  background-color: var(--fivra-button-ghost-bg-hover);
-}
-
-${BASE_CLASS}:active:not(:disabled) {
-  background-color: var(--fivra-button-primary-bg-active);
+${BASE_CLASS}:active:not(:disabled):not([aria-disabled='true']) {
+  background-color: var(--fivra-button-bg-active);
   transform: translateY(1px);
-}
-
-${BASE_CLASS}[data-variant='secondary']:active:not(:disabled) {
-  background-color: var(--fivra-button-secondary-bg-active);
-}
-
-${BASE_CLASS}[data-variant='ghost']:active:not(:disabled) {
-  background-color: var(--fivra-button-ghost-bg-active);
 }
 
 ${BASE_CLASS}:focus-visible {
@@ -143,8 +141,41 @@ ${BASE_CLASS}:focus-visible {
 ${BASE_CLASS}:disabled,
 ${BASE_CLASS}[aria-disabled='true'] {
   cursor: not-allowed;
-  opacity: 0.5;
   box-shadow: none;
+  background-color: var(--fivra-button-disabled-bg);
+  border-color: var(--fivra-button-disabled-border);
+  color: var(--fivra-button-disabled-text);
+}
+
+${BASE_CLASS}[data-icon-only='true'] {
+  --fivra-button-gap: 0;
+  --fivra-button-padding-x: 0;
+  width: var(--fivra-button-height);
+  padding-left: 0;
+  padding-right: 0;
+  border-radius: var(--radiusMax);
+}
+
+${BASE_CLASS}[data-has-label='false'] ${LABEL_CLASS} {
+  display: none;
+}
+
+${BASE_CLASS}[data-dropdown='true'] ${CARET_CLASS} {
+  display: inline-flex;
+}
+
+${BASE_CLASS}[data-loading='true'] {
+  cursor: progress;
+}
+
+${BASE_CLASS}[data-loading='true'] ${ICON_CLASS},
+${BASE_CLASS}[data-loading='true'] ${LABEL_CLASS},
+${BASE_CLASS}[data-loading='true'] ${CARET_CLASS} {
+  opacity: 0;
+}
+
+${BASE_CLASS}[data-loading='true'] ${SPINNER_CLASS} {
+  display: inline-flex;
 }
 
 ${ICON_CLASS} {
@@ -172,6 +203,53 @@ ${LABEL_CLASS} {
   align-items: center;
   justify-content: center;
   white-space: nowrap;
+}
+
+${SPINNER_CLASS} {
+  position: absolute;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+}
+
+${SPINNER_CLASS}::before {
+  content: '';
+  width: var(--fivra-button-spinner-size);
+  height: var(--fivra-button-spinner-size);
+  border-radius: 999px;
+  border: calc(var(--borderwidthS) * 1px) solid var(--borderPrimaryDisabled);
+  border-top-color: var(--textPrimaryInteractive);
+  animation: fivra-button-spin 0.8s linear infinite;
+}
+
+${CARET_CLASS} {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: var(--fivra-button-icon-size);
+  height: var(--fivra-button-icon-size);
+  flex-shrink: 0;
+}
+
+${CARET_CLASS}::before {
+  content: '';
+  display: block;
+  width: 0;
+  height: 0;
+  border-left: calc(var(--fivra-button-icon-size) / 3) solid transparent;
+  border-right: calc(var(--fivra-button-icon-size) / 3) solid transparent;
+  border-top: calc(var(--fivra-button-icon-size) / 3) solid currentColor;
+}
+
+@keyframes fivra-button-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }
 `;
 
@@ -203,7 +281,7 @@ export function ensureButtonStyles(): void {
 
   const style = document.createElement('style');
   style.dataset.fivraButtonStyles = 'true';
-  style.textContent = `${buttonClassStyles}`;
+  style.textContent = `${buttonHostStyles}${buttonClassStyles}`;
   document.head.appendChild(style);
   hasInjectedStyles = true;
 }

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -55,7 +55,7 @@ ${BASE_CLASS} {
   padding: var(--fivra-button-padding-y) var(--fivra-button-padding-x);
   min-height: var(--fivra-button-height);
   min-width: var(--fivra-button-height);
-  border-radius: var(--fivra-button-radius);
+  border-radius: calc(var(--fivra-button-radius) * 1px);
   border-width: calc(var(--borderwidthS) * 1px);
   border-style: solid;
   border-color: var(--fivra-button-border);
@@ -147,13 +147,29 @@ ${BASE_CLASS}[aria-disabled='true'] {
   color: var(--fivra-button-disabled-text);
 }
 
+${BASE_CLASS}[data-loading='true'] {
+  cursor: progress;
+  background-color: var(--fivra-button-bg);
+  border-color: var(--fivra-button-border);
+  color: var(--fivra-button-text);
+  box-shadow: var(--fivra-button-shadow);
+}
+
+${BASE_CLASS}[data-loading='true']:disabled,
+${BASE_CLASS}[data-loading='true'][aria-disabled='true'] {
+  background-color: var(--fivra-button-bg);
+  border-color: var(--fivra-button-border);
+  color: var(--fivra-button-text);
+  box-shadow: var(--fivra-button-shadow);
+}
+
 ${BASE_CLASS}[data-icon-only='true'] {
   --fivra-button-gap: 0;
   --fivra-button-padding-x: 0;
   width: var(--fivra-button-height);
   padding-left: 0;
   padding-right: 0;
-  border-radius: var(--radiusMax);
+  border-radius: calc(var(--radiusMax) * 1px);
 }
 
 ${BASE_CLASS}[data-has-label='false'] ${LABEL_CLASS} {
@@ -162,10 +178,6 @@ ${BASE_CLASS}[data-has-label='false'] ${LABEL_CLASS} {
 
 ${BASE_CLASS}[data-dropdown='true'] ${CARET_CLASS} {
   display: inline-flex;
-}
-
-${BASE_CLASS}[data-loading='true'] {
-  cursor: progress;
 }
 
 ${BASE_CLASS}[data-loading='true'] ${ICON_CLASS},
@@ -220,7 +232,7 @@ ${SPINNER_CLASS}::before {
   height: var(--fivra-button-spinner-size);
   border-radius: 999px;
   border: calc(var(--borderwidthS) * 1px) solid var(--borderPrimaryDisabled);
-  border-top-color: var(--textPrimaryInteractive);
+  border-top-color: var(--fivra-button-text);
   animation: fivra-button-spin 0.8s linear infinite;
 }
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -6,6 +6,8 @@ export {
   BUTTON_LABEL_CLASS,
   BUTTON_LEADING_ICON_CLASS,
   BUTTON_TRAILING_ICON_CLASS,
+  BUTTON_SPINNER_CLASS,
+  BUTTON_CARET_CLASS,
   buttonClassStyles,
   buttonHostStyles,
   ensureButtonStyles,

--- a/src/web-components/AGENTS.md
+++ b/src/web-components/AGENTS.md
@@ -11,3 +11,4 @@ This directory extends the repository and `src/components/` guidance for custom 
 - 1.0: Registered the `<fivra-button>` custom element that mirrors the shared Button styles and attributes.
 - 1.0: Ensured `defineDesignSystemElements` explicitly imports `defineFivraButton` to support isolated DTS builds.
 - 1.0: Synced injected button styles with tokenized variables so the custom element reflects theme spacing, colors, and focus states.
+- 1.2.0: Synced icon-only, dropdown, loading, and tertiary variant behavior with the React adapter, including new data attributes and ARIA forwarding.


### PR DESCRIPTION
## Summary
- rename the ghost button variant to tertiary and align base spacing, radius, and token assignments across sizes
- add icon-only, dropdown, and loading affordances with spinner/caret hooks for both the React and web component buttons
- refresh stories, docs, and tests plus update AGENTS logs and add a changeset for the new API surface

## Testing
- yarn generate:icons
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68da625e4438832c96e7082cac757b70