### PR TITLE
feat(button): accent-driven state overlays

### DIFF
--- a/.changeset/purple-signs-post.md
+++ b/.changeset/purple-signs-post.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": minor
+---
+
+Implement accent-driven color-mix state layers for Button variants and document semantic overrides.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -12,3 +12,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.0: Button styling variables now map directly to Engage/Legacy design tokens (backgrounds, states, spacing, radii, icon sizes).
 - 1.2.0: Added the tertiary variant, icon-only/dropdown/loading affordances, and explicit token-aligned spacing across implementations.
 - 1.2.1: Corrected radius scaling, loading-state colors, and the custom element preview to match the updated button contract.
+- 1.3.0: State layers now derive from accent-driven `color-mix()` overlays with documented semantic overrides in Storybook.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -5,6 +5,36 @@ import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import { defineFivraButton } from "@web-components";
 
+const SEMANTIC_TONES = ["Success", "Warning", "Error"] as const;
+type SemanticTone = (typeof SEMANTIC_TONES)[number];
+
+const createPrimarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
+  ({
+    "--fivra-button-surface": `var(--backgroundPrimary${tone})`,
+    "--fivra-button-accent": `var(--backgroundPrimary${tone})`,
+    "--fivra-button-border": `var(--borderPrimary${tone})`,
+    "--fivra-button-text": "var(--backgroundNeutral0)",
+    "--fivra-button-hover-fallback": `var(--backgroundPrimary${tone})`,
+    "--fivra-button-active-fallback": `var(--backgroundPrimary${tone})`,
+  }) as React.CSSProperties;
+
+const createSecondarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
+  ({
+    "--fivra-button-accent": `var(--textPrimary${tone})`,
+    "--fivra-button-border": `var(--borderPrimary${tone})`,
+    "--fivra-button-text": `var(--textPrimary${tone})`,
+    "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
+    "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
+  }) as React.CSSProperties;
+
+const createTertiarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
+  ({
+    "--fivra-button-accent": `var(--textPrimary${tone})`,
+    "--fivra-button-text": `var(--textPrimary${tone})`,
+    "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
+    "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
+  }) as React.CSSProperties;
+
 const meta: Meta<typeof Button> = {
   title: "Components/Button/React",
   component: Button,
@@ -85,7 +115,7 @@ export const Primary: Story = {
     docs: {
       description: {
         story:
-          "Primary button emphasizes the main action using '--backgroundPrimaryInteractive' with contrast text from '--backgroundNeutral0'.",
+          "Primary buttons emphasize the main action using '--backgroundPrimaryInteractive' and now blend hover, focus, and press layers via `color-mix()` driven by the same accent variable.",
       },
     },
   },
@@ -100,7 +130,7 @@ export const Secondary: Story = {
     docs: {
       description: {
         story:
-          "Secondary buttons pair `--backgroundNeutral0` with `--borderPrimaryInteractive` to deliver a neutral outline that still shares the brand hover tokens.",
+          "Secondary buttons pair `--backgroundNeutral0` with `--borderPrimaryInteractive`, tinting their state layers from the accent so outline variants can adopt semantic hues.",
       },
     },
   },
@@ -115,7 +145,7 @@ export const Tertiary: Story = {
     docs: {
       description: {
         story:
-          "Tertiary buttons stay transparent until interaction, relying on `--textPrimaryInteractive` and the selected background overlay tokens for hover and press states.",
+          "Tertiary buttons stay transparent until interaction and inherit hover/press overlays from the accent color, keeping ghost actions lightweight yet brand-aware.",
       },
     },
   },
@@ -147,6 +177,78 @@ export const DisabledStates: Story = {
       description: {
         story:
           "Disabled states pull from `--backgroundPrimaryDisabled`, `--backgroundSecondaryDisabled`, and `--textPrimaryDisabled` ensuring consistent contrast and borders via `--borderPrimaryDisabled`.",
+      },
+    },
+  },
+};
+
+export const SemanticOverrides: Story = {
+  name: "Semantic Overrides",
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gap: "calc(var(--spacingM) * 1px)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          gap: "calc(var(--spacingL) * 1px)",
+          flexWrap: "wrap",
+        }}
+      >
+        {SEMANTIC_TONES.map((tone) => (
+          <Button
+            key={`primary-${tone}`}
+            variant="primary"
+            style={createPrimarySemanticStyles(tone)}
+          >
+            {tone} Primary
+          </Button>
+        ))}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: "calc(var(--spacingL) * 1px)",
+          flexWrap: "wrap",
+        }}
+      >
+        {SEMANTIC_TONES.map((tone) => (
+          <Button
+            key={`secondary-${tone}`}
+            variant="secondary"
+            style={createSecondarySemanticStyles(tone)}
+          >
+            {tone} Secondary
+          </Button>
+        ))}
+      </div>
+      <div
+        style={{
+          display: "flex",
+          gap: "calc(var(--spacingL) * 1px)",
+          flexWrap: "wrap",
+        }}
+      >
+        {SEMANTIC_TONES.map((tone) => (
+          <Button
+            key={`tertiary-${tone}`}
+            variant="tertiary"
+            style={createTertiarySemanticStyles(tone)}
+          >
+            {tone} Tertiary
+          </Button>
+        ))}
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Setting the `--fivra-button-accent` custom property enables success, warning, and error palettes while the new color-mix state layers adapt automatically. Fallback variables keep neutral overlays for browsers without color-mix support.",
       },
     },
   },

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -1,3 +1,5 @@
+import { COLOR_MIX_SUPPORTS_DECLARATION, colorMix } from '../../styles/color-mix';
+
 export const BUTTON_CLASS_NAME = 'fivra-button';
 export const BUTTON_ICON_CLASS = `${BUTTON_CLASS_NAME}__icon`;
 export const BUTTON_LABEL_CLASS = `${BUTTON_CLASS_NAME}__label`;
@@ -36,9 +38,10 @@ ${BASE_CLASS} {
   --fivra-button-height: calc(32 * 1px);
   --fivra-button-icon-size: var(--iconsizesM);
   --fivra-button-spinner-size: calc(16 * 1px);
-  --fivra-button-bg: var(--backgroundPrimaryInteractive);
-  --fivra-button-bg-hover: var(--stateBrandHover);
-  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-surface: var(--backgroundPrimaryInteractive);
+  --fivra-button-accent: var(--backgroundPrimaryInteractive);
+  --fivra-button-hover-fallback: var(--stateBrandHover);
+  --fivra-button-active-fallback: var(--stateBrandPress);
   --fivra-button-border: var(--borderPrimaryInteractive);
   --fivra-button-text: var(--backgroundNeutral0);
   --fivra-button-disabled-bg: var(--backgroundPrimaryDisabled);
@@ -59,7 +62,7 @@ ${BASE_CLASS} {
   border-width: calc(var(--borderwidthS) * 1px);
   border-style: solid;
   border-color: var(--fivra-button-border);
-  background-color: var(--fivra-button-bg);
+  background-color: var(--fivra-button-surface);
   color: var(--fivra-button-text);
   font-family: var(--fivra-button-font-family);
   font-weight: var(--fivra-button-font-weight);
@@ -102,9 +105,10 @@ ${BASE_CLASS}[data-size='lg'] {
 }
 
 ${BASE_CLASS}[data-variant='secondary'] {
-  --fivra-button-bg: var(--backgroundNeutral0);
-  --fivra-button-bg-hover: var(--backgroundPrimarySelected);
-  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-surface: var(--backgroundNeutral0);
+  --fivra-button-accent: var(--textPrimaryInteractive);
+  --fivra-button-hover-fallback: var(--backgroundPrimarySelected);
+  --fivra-button-active-fallback: var(--stateBrandPress);
   --fivra-button-border: var(--borderPrimaryInteractive);
   --fivra-button-text: var(--textPrimaryInteractive);
   --fivra-button-disabled-bg: var(--backgroundSecondaryDisabled);
@@ -113,9 +117,10 @@ ${BASE_CLASS}[data-variant='secondary'] {
 }
 
 ${BASE_CLASS}[data-variant='tertiary'] {
-  --fivra-button-bg: transparent;
-  --fivra-button-bg-hover: var(--backgroundPrimarySelected);
-  --fivra-button-bg-active: var(--stateBrandPress);
+  --fivra-button-surface: transparent;
+  --fivra-button-accent: var(--textPrimaryInteractive);
+  --fivra-button-hover-fallback: var(--backgroundPrimarySelected);
+  --fivra-button-active-fallback: var(--stateBrandPress);
   --fivra-button-border: transparent;
   --fivra-button-text: var(--textPrimaryInteractive);
   --fivra-button-disabled-bg: transparent;
@@ -123,13 +128,42 @@ ${BASE_CLASS}[data-variant='tertiary'] {
   --fivra-button-disabled-text: var(--textPrimaryDisabled);
 }
 
-${BASE_CLASS}:hover:not(:disabled):not([aria-disabled='true']) {
-  background-color: var(--fivra-button-bg-hover);
+@supports (${COLOR_MIX_SUPPORTS_DECLARATION}) {
+  ${BASE_CLASS} {
+    --fivra-button-focus-ring-color: ${colorMix({
+      layerColor: 'var(--stateLayerBrightenBase)',
+      layerPercentage: 'var(--intensityBrandFocusPercent)',
+      accentColor: 'var(--fivra-button-accent)',
+    })};
+  }
+
+  ${BASE_CLASS}:hover:not(:disabled):not([aria-disabled='true']) {
+    background-color: ${colorMix({
+      layerColor: 'var(--stateLayerBrightenBase)',
+      layerPercentage: 'var(--intensityBrandHoverPercent)',
+      accentColor: 'var(--fivra-button-accent)',
+    })};
+  }
+
+  ${BASE_CLASS}:active:not(:disabled):not([aria-disabled='true']) {
+    background-color: ${colorMix({
+      layerColor: 'var(--stateLayerDarkenBase)',
+      layerPercentage: 'var(--intensityBrandActivePercent)',
+      accentColor: 'var(--fivra-button-accent)',
+    })};
+    transform: translateY(1px);
+  }
 }
 
-${BASE_CLASS}:active:not(:disabled):not([aria-disabled='true']) {
-  background-color: var(--fivra-button-bg-active);
-  transform: translateY(1px);
+@supports not (${COLOR_MIX_SUPPORTS_DECLARATION}) {
+  ${BASE_CLASS}:hover:not(:disabled):not([aria-disabled='true']) {
+    background-color: var(--fivra-button-hover-fallback);
+  }
+
+  ${BASE_CLASS}:active:not(:disabled):not([aria-disabled='true']) {
+    background-color: var(--fivra-button-active-fallback);
+    transform: translateY(1px);
+  }
 }
 
 ${BASE_CLASS}:focus-visible {
@@ -149,7 +183,7 @@ ${BASE_CLASS}[aria-disabled='true'] {
 
 ${BASE_CLASS}[data-loading='true'] {
   cursor: progress;
-  background-color: var(--fivra-button-bg);
+  background-color: var(--fivra-button-surface);
   border-color: var(--fivra-button-border);
   color: var(--fivra-button-text);
   box-shadow: var(--fivra-button-shadow);
@@ -157,7 +191,7 @@ ${BASE_CLASS}[data-loading='true'] {
 
 ${BASE_CLASS}[data-loading='true']:disabled,
 ${BASE_CLASS}[data-loading='true'][aria-disabled='true'] {
-  background-color: var(--fivra-button-bg);
+  background-color: var(--fivra-button-surface);
   border-color: var(--fivra-button-border);
   color: var(--fivra-button-text);
   box-shadow: var(--fivra-button-shadow);

--- a/src/styles/AGENTS.md
+++ b/src/styles/AGENTS.md
@@ -11,3 +11,4 @@ This file inherits the repository root `AGENTS.md`. Generated theme assets live 
 - 1.0: Added layered `index.css`, theme helpers, and scoped CSS selectors so `data-fivra-theme` toggles Engage/Legacy tokens.
 - 1.1.0: Corrected Storybook bundle imports to use `@import ... layer(...)` so generated theme variables resolve reliably.
 - 1.2.0: Regenerated Engage and Legacy theme CSS with percent intensity helpers and neutral state-layer aliases.
+- 1.3.0: Added a shared `color-mix` utility for components to compose state-layer overlays.

--- a/src/styles/color-mix.ts
+++ b/src/styles/color-mix.ts
@@ -1,0 +1,19 @@
+const DEFAULT_COLOR_SPACE = 'srgb';
+export const COLOR_MIX_SUPPORTS_DECLARATION =
+  'color: color-mix(in srgb, #000 0%, #fff 100%)';
+
+interface ColorMixOptions {
+  layerColor: string;
+  layerPercentage: string;
+  accentColor: string;
+  colorSpace?: string;
+}
+
+export function colorMix({
+  layerColor,
+  layerPercentage,
+  accentColor,
+  colorSpace = DEFAULT_COLOR_SPACE,
+}: ColorMixOptions): string {
+  return `color-mix(in ${colorSpace}, ${layerColor} ${layerPercentage}, ${accentColor})`;
+}


### PR DESCRIPTION
## Summary
- add a shared `color-mix` helper and update button styles to derive hover/active/focus layers from accent-driven mixes with fallbacks
- wire secondary and tertiary variants plus Storybook docs to demonstrate semantic accent overrides, including success/warning/error examples
- record the behavior change in the component/style AGENTS files and add a changeset entry

## Testing
- yarn generate:icons
- yarn build
- yarn test


------
https://chatgpt.com/codex/tasks/task_e_68db1e299f38832ca2f40d666a02859f