### PR TITLE
Ensure primary hover halo uses layer color mix weighting

### DIFF
--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -15,3 +15,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.3.0: State layers now derive from accent-driven `color-mix()` overlays with documented semantic overrides in Storybook.
 - 1.4.0: Added per-variant overlay custom properties that weight neutral variants toward their accent color and documented/tested the behavior across React and web components.
 - 1.5.0: Introduced halo custom properties for hover, active, and focus states to deliver consistent glow styling across implementations.
+- 1.5.1: Primary hover halo now targets the layer mix to align with the hover background weighting across implementations.

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -153,6 +153,7 @@ ${BASE_CLASS}[data-variant='tertiary'] {
       layerColor: 'var(--stateLayerBrightenBase)',
       layerPercentage: 'var(--intensityBrandHoverPercent)',
       accentColor: 'var(--fivra-button-accent)',
+      weightTarget: 'layer',
     })};
     --fivra-button-active-color: ${colorMix({
       layerColor: 'var(--stateLayerDarkenBase)',
@@ -163,6 +164,7 @@ ${BASE_CLASS}[data-variant='tertiary'] {
       layerColor: 'var(--stateLayerBrightenBase)',
       layerPercentage: 'var(--intensityBrandHoverPercent)',
       accentColor: 'var(--fivra-button-accent)',
+      weightTarget: 'layer',
     })};
     --fivra-button-active-halo: ${colorMix({
       layerColor: 'var(--stateLayerDarkenBase)',


### PR DESCRIPTION
## Summary
- align the primary button hover halo mix to weight its layer component like the hover background
- log the halo weighting adjustment in the Button directory guidelines

## Testing
- yarn generate:icons
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dc05e94b20832c8e982ecd2e150b78