### PR TITLE
Add balanced halo utility for button halos

### DIFF
--- a/.changeset/balanced-halo-button.md
+++ b/.changeset/balanced-halo-button.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": minor
+---
+
+Add a balanced halo utility and matching custom element attribute so button halos can be weighted toward the accent color with consistent fallbacks.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -17,3 +17,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.5.0: Introduced halo custom properties for hover, active, and focus states to deliver consistent glow styling across implementations.
 - 1.5.1: Primary hover halo now targets the layer mix to align with the hover background weighting across implementations.
 - 1.6.0: Defaulted the button font family to the generated body token so React and web component builds use Google Sans.
+- 1.7.0: Added the balanced halo utility class with React/Web Component toggles, documentation, and tests to reweight glow mixes toward the accent color.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -42,6 +42,7 @@ const meta: Meta<typeof Button> = {
   args: {
     children: "Button",
     variant: "primary",
+    balancedHalo: false,
   },
   argTypes: {
     onClick: { action: "clicked" },
@@ -90,6 +91,12 @@ const meta: Meta<typeof Button> = {
       control: "boolean",
       description: "Displays a spinner with `aria-busy` set on the underlying `<button>`.",
       table: { category: "State" },
+    },
+    balancedHalo: {
+      control: "boolean",
+      description:
+        "Reweights the hover, active, and focus halos toward the accent color by adding the `fivra-button--balanced-halo` utility class.",
+      table: { category: "Appearance" },
     },
   },
   parameters: {
@@ -249,6 +256,44 @@ export const SemanticOverrides: Story = {
       description: {
         story:
           "Setting the `--fivra-button-accent` custom property enables success, warning, and error palettes while the new per-variant color-mix state layers adapt automatically. Fallback variables keep neutral overlays for browsers without color-mix support.",
+      },
+    },
+  },
+};
+
+const BalancedHaloPreview: React.FC = () => {
+  React.useEffect(() => {
+    defineFivraButton();
+  }, []);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: "calc(var(--spacingL) * 1px)",
+        alignItems: "center",
+        flexWrap: "wrap",
+      }}
+    >
+      <Button variant="primary">Default halo</Button>
+      <Button variant="primary" balancedHalo>
+        Balanced halo
+      </Button>
+      <fivra-button balanced-halo>
+        Balanced halo (web)
+      </fivra-button>
+    </div>
+  );
+};
+
+export const BalancedHalo: Story = {
+  name: "Balanced Halo",
+  render: () => <BalancedHaloPreview />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Apply the `balancedHalo` prop or `balanced-halo` attribute to shift the halo custom properties toward the accent mix when primary buttons need a softer glow.",
       },
     },
   },

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -8,6 +8,7 @@ import {
   BUTTON_TRAILING_ICON_CLASS,
   BUTTON_SPINNER_CLASS,
   BUTTON_CARET_CLASS,
+  BUTTON_BALANCED_HALO_CLASS,
   DEFAULT_BUTTON_SIZE,
   DEFAULT_BUTTON_VARIANT,
   type ButtonSize,
@@ -38,6 +39,8 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   dropdown?: boolean;
   /** Displays a spinner and marks the button as busy. */
   loading?: boolean;
+  /** Reweights the hover, active, and focus halos toward the accent color. */
+  balancedHalo?: boolean;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props, ref) {
@@ -51,6 +54,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props,
     hasLabel,
     dropdown = false,
     loading = false,
+    balancedHalo = false,
     className,
     children,
     type,
@@ -86,7 +90,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(props,
       {...rest}
       ref={ref}
       type={buttonType}
-      className={cx(BUTTON_CLASS_NAME, className ?? undefined)}
+      className={cx(
+        BUTTON_CLASS_NAME,
+        balancedHalo && BUTTON_BALANCED_HALO_CLASS,
+        className ?? undefined,
+      )}
       data-variant={variant}
       data-size={size}
       data-full-width={fullWidth ? 'true' : undefined}

--- a/src/components/Button/__tests__/Button.test.tsx
+++ b/src/components/Button/__tests__/Button.test.tsx
@@ -98,7 +98,7 @@ describe('Button', () => {
       "--fivra-button-hover-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandHoverPercent), var(--fivra-button-accent));",
     );
     expect(textContent).toContain(
-      "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerDarkenBase) var(--intensityBrandActivePercent), var(--fivra-button-accent));",
+      "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandActivePercent), var(--fivra-button-accent));",
     );
     expect(textContent).toContain(
       "--fivra-button-focus-ring-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandFocusPercent), var(--fivra-button-accent));",
@@ -122,13 +122,57 @@ describe('Button', () => {
       "--fivra-button-hover-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandHoverPercent));",
     );
     expect(textContent).toContain(
-      "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerDarkenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));",
+      "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));",
     );
     expect(textContent).toContain(
       "--fivra-button-focus-ring-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandFocusPercent));",
     );
     expect(textContent).toContain(
       ".fivra-button[data-variant='tertiary'] {",
+    );
+  });
+
+  it('balances the primary halo toward the accent when requested', () => {
+    ensureButtonStyles();
+
+    render(
+      <>
+        <Button data-testid="default">Default Halo</Button>
+        <Button data-testid="balanced" balancedHalo>
+          Balanced Halo
+        </Button>
+      </>,
+    );
+
+    const balancedButton = screen.getByTestId('balanced');
+
+    expect(balancedButton.className).toContain('fivra-button--balanced-halo');
+
+    const style = document.querySelector<HTMLStyleElement>(
+      'style[data-fivra-button-styles="true"]',
+    );
+
+    expect(style).toBeInstanceOf(HTMLStyleElement);
+    const textContent = style?.textContent ?? '';
+
+    expect(textContent).toContain('.fivra-button.fivra-button--balanced-halo {');
+    expect(textContent).toContain(
+      "--fivra-button-hover-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandHoverPercent));",
+    );
+    expect(textContent).toContain(
+      "--fivra-button-active-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));",
+    );
+    expect(textContent).toContain(
+      "--fivra-button-focus-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandFocusPercent));",
+    );
+    expect(textContent).toContain(
+      "--fivra-button-hover-halo: var(--fivra-button-hover-halo-fallback);",
+    );
+    expect(textContent).toContain(
+      "--fivra-button-active-halo: var(--fivra-button-active-halo-fallback);",
+    );
+    expect(textContent).toContain(
+      "--fivra-button-focus-halo: var(--fivra-button-focus-halo-fallback);",
     );
   });
 });

--- a/src/components/Button/button.styles.ts
+++ b/src/components/Button/button.styles.ts
@@ -7,6 +7,7 @@ export const BUTTON_LEADING_ICON_CLASS = `${BUTTON_ICON_CLASS}--leading`;
 export const BUTTON_TRAILING_ICON_CLASS = `${BUTTON_ICON_CLASS}--trailing`;
 export const BUTTON_SPINNER_CLASS = `${BUTTON_CLASS_NAME}__spinner`;
 export const BUTTON_CARET_CLASS = `${BUTTON_CLASS_NAME}__caret`;
+export const BUTTON_BALANCED_HALO_CLASS = `${BUTTON_CLASS_NAME}--balanced-halo`;
 
 export type ButtonVariant = 'primary' | 'secondary' | 'tertiary';
 export type ButtonSize = 'sm' | 'md' | 'lg';
@@ -22,6 +23,7 @@ const ICON_CLASS = `.${BUTTON_ICON_CLASS}`;
 const LABEL_CLASS = `.${BUTTON_LABEL_CLASS}`;
 const SPINNER_CLASS = `.${BUTTON_SPINNER_CLASS}`;
 const CARET_CLASS = `.${BUTTON_CARET_CLASS}`;
+const BALANCED_HALO_CLASS = `${BASE_CLASS}.${BUTTON_BALANCED_HALO_CLASS}`;
 
 export const buttonClassStyles = `
 ${BASE_CLASS} {
@@ -179,6 +181,27 @@ ${BASE_CLASS}[data-variant='tertiary'] {
     })};
   }
 
+  ${BALANCED_HALO_CLASS} {
+    --fivra-button-hover-halo: ${colorMix({
+      layerColor: 'var(--stateLayerBrightenBase)',
+      layerPercentage: 'var(--intensityBrandHoverPercent)',
+      accentColor: 'var(--fivra-button-accent)',
+      weightTarget: 'accent',
+    })};
+    --fivra-button-active-halo: ${colorMix({
+      layerColor: 'var(--stateLayerBrightenBase)',
+      layerPercentage: 'var(--intensityBrandActivePercent)',
+      accentColor: 'var(--fivra-button-accent)',
+      weightTarget: 'accent',
+    })};
+    --fivra-button-focus-halo: ${colorMix({
+      layerColor: 'var(--stateLayerBrightenBase)',
+      layerPercentage: 'var(--intensityBrandFocusPercent)',
+      accentColor: 'var(--fivra-button-accent)',
+      weightTarget: 'accent',
+    })};
+  }
+
   ${BASE_CLASS}[data-variant='secondary'] {
     --fivra-button-focus-ring-color: ${colorMix({
       layerColor: 'var(--stateLayerBrightenBase)',
@@ -281,6 +304,12 @@ ${BASE_CLASS}[data-variant='tertiary'] {
     box-shadow: var(--fivra-button-shadow),
       0 0 0 6px var(--fivra-button-active-halo-fallback);
     transform: translateY(1px);
+  }
+
+  ${BALANCED_HALO_CLASS} {
+    --fivra-button-hover-halo: var(--fivra-button-hover-halo-fallback);
+    --fivra-button-active-halo: var(--fivra-button-active-halo-fallback);
+    --fivra-button-focus-halo: var(--fivra-button-focus-halo-fallback);
   }
 }
 

--- a/src/components/Button/index.ts
+++ b/src/components/Button/index.ts
@@ -8,6 +8,7 @@ export {
   BUTTON_TRAILING_ICON_CLASS,
   BUTTON_SPINNER_CLASS,
   BUTTON_CARET_CLASS,
+  BUTTON_BALANCED_HALO_CLASS,
   buttonClassStyles,
   buttonHostStyles,
   ensureButtonStyles,

--- a/src/web-components/AGENTS.md
+++ b/src/web-components/AGENTS.md
@@ -13,3 +13,4 @@ This directory extends the repository and `src/components/` guidance for custom 
 - 1.0: Synced injected button styles with tokenized variables so the custom element reflects theme spacing, colors, and focus states.
 - 1.2.0: Synced icon-only, dropdown, loading, and tertiary variant behavior with the React adapter, including new data attributes and ARIA forwarding.
 - 1.2.1: Added overlay mix regression tests to ensure brand versus neutral button states stay aligned with the React implementation.
+- 1.3.0: Introduced the `balanced-halo` attribute to mirror the new utility class and verified accent-weighted halos through unit tests.

--- a/src/web-components/__tests__/button.test.ts
+++ b/src/web-components/__tests__/button.test.ts
@@ -5,13 +5,13 @@ import { defineFivraButton, FivraButtonElement } from '@web-components';
 const BRAND_HOVER_MIX =
   "--fivra-button-hover-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandHoverPercent), var(--fivra-button-accent));";
 const BRAND_ACTIVE_MIX =
-  "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerDarkenBase) var(--intensityBrandActivePercent), var(--fivra-button-accent));";
+  "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandActivePercent), var(--fivra-button-accent));";
 const BRAND_FOCUS_MIX =
   "--fivra-button-focus-ring-color: color-mix(in srgb, var(--stateLayerBrightenBase) var(--intensityBrandFocusPercent), var(--fivra-button-accent));";
 const ACCENT_HOVER_MIX =
   "--fivra-button-hover-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandHoverPercent));";
 const ACCENT_ACTIVE_MIX =
-  "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerDarkenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));";
+  "--fivra-button-active-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));";
 const ACCENT_FOCUS_MIX =
   "--fivra-button-focus-ring-color: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandFocusPercent));";
 
@@ -50,5 +50,35 @@ describe('FivraButtonElement styles', () => {
     expect(styles).toContain(ACCENT_ACTIVE_MIX);
     expect(styles).toContain(ACCENT_FOCUS_MIX);
     expect(styles).toContain(".fivra-button[data-variant='tertiary'] {");
+  });
+
+  it('applies the balanced halo weighting when the attribute is set', () => {
+    const balancedElement = document.createElement('fivra-button') as FivraButtonElement;
+    balancedElement.setAttribute('balanced-halo', '');
+    document.body.appendChild(balancedElement);
+
+    const balancedButton = balancedElement.shadowRoot?.querySelector('button') as HTMLButtonElement;
+    const styles = queryShadowStyles(balancedElement);
+
+    expect(balancedButton.className).toContain('fivra-button--balanced-halo');
+    expect(styles).toContain('.fivra-button.fivra-button--balanced-halo {');
+    expect(styles).toContain(
+      "--fivra-button-hover-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandHoverPercent));",
+    );
+    expect(styles).toContain(
+      "--fivra-button-active-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandActivePercent));",
+    );
+    expect(styles).toContain(
+      "--fivra-button-focus-halo: color-mix(in srgb, var(--stateLayerBrightenBase), var(--fivra-button-accent) var(--intensityBrandFocusPercent));",
+    );
+    expect(styles).toContain(
+      "--fivra-button-hover-halo: var(--fivra-button-hover-halo-fallback);",
+    );
+    expect(styles).toContain(
+      "--fivra-button-active-halo: var(--fivra-button-active-halo-fallback);",
+    );
+    expect(styles).toContain(
+      "--fivra-button-focus-halo: var(--fivra-button-focus-halo-fallback);",
+    );
   });
 });

--- a/src/web-components/button.ts
+++ b/src/web-components/button.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_BUTTON_VARIANT,
   BUTTON_SIZES,
   BUTTON_VARIANTS,
+  BUTTON_BALANCED_HALO_CLASS,
   buttonClassStyles,
   buttonHostStyles,
 } from '@components/Button/button.styles';
@@ -58,6 +59,7 @@ export class FivraButtonElement extends HTMLElement {
       'dropdown',
       'loading',
       'has-label',
+      'balanced-halo',
       'aria-label',
       'aria-labelledby',
     ];
@@ -180,6 +182,15 @@ export class FivraButtonElement extends HTMLElement {
     this.syncLoading();
   }
 
+  get balancedHalo(): boolean {
+    return this.hasAttribute('balanced-halo');
+  }
+
+  set balancedHalo(value: boolean) {
+    this.toggleAttribute('balanced-halo', value);
+    this.syncBalancedHalo();
+  }
+
   get hasLabel(): boolean {
     const attr = this.getAttribute('has-label');
     if (attr !== null) {
@@ -204,6 +215,7 @@ export class FivraButtonElement extends HTMLElement {
     this.syncIconOnly();
     this.syncDropdown();
     this.syncLoading();
+    this.syncBalancedHalo();
     this.syncHasLabel();
     this.syncAriaAttributes();
   };
@@ -285,6 +297,10 @@ export class FivraButtonElement extends HTMLElement {
       delete this.buttonEl.dataset.loading;
       this.buttonEl.removeAttribute('aria-busy');
     }
+  }
+
+  private syncBalancedHalo(): void {
+    this.buttonEl.classList.toggle(BUTTON_BALANCED_HALO_CLASS, this.balancedHalo);
   }
 
   private syncHasLabel(): void {


### PR DESCRIPTION
## Summary
- add a `fivra-button--balanced-halo` utility that reweights halo custom properties toward the accent mix with color-mix fallbacks
- expose a `balancedHalo` prop on the React button, mirror it with a `balanced-halo` attribute on the web component, and document the usage in Storybook
- extend React and web component tests plus directory agent notes and add a changeset for the new behavior

## Testing
- yarn generate:icons
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dc2525d764832ca413f47cfdc67abf