### PR TITLE
Gate Storybook composition refs behind env toggles

### DIFF
--- a/.changeset/react-manager-compose-toggles.md
+++ b/.changeset/react-manager-compose-toggles.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Gate Angular and Vue Storybook refs behind env toggles and document the React-only workflow.

--- a/.storybook/AGENTS.md
+++ b/.storybook/AGENTS.md
@@ -12,6 +12,7 @@ This document augments the repository root `AGENTS.md`. Review root conventions 
 - When updating addons or frameworks, validate compatibility with our accessibility, docs, and design tooling before committing.
 - Document notable configuration changes in PR descriptions and cross-reference related updates under `src/stories/` when behavior changes.
 - Use `yarn storybook` to validate Storybook refs locally; the command launches the React, Angular, and Vue workspaces together on ports 6006/6007/6008.
+- Toggle Angular/Vue composition by setting `STORYBOOK_COMPOSE_ANGULAR` and `STORYBOOK_COMPOSE_VUE` (defaults to `true` for the composed workflow).
 
 ## Review Checklist
 - Ensure `yarn storybook`, `yarn build-storybook`, and TypeScript type checks succeed after modifying configuration.
@@ -26,3 +27,4 @@ This document augments the repository root `AGENTS.md`. Review root conventions 
 - 1.3.0: Introduced Storybook composition refs, the runtime manager entry, and the `storybook:compose`/`build-storybook` orchestration workflow.
 - 1.3.1: Updated preview typing to reference `@storybook/react-vite` after running the automigration tooling.
 - 1.4.0: Simplified refs configuration and promoted the composed workflow to `yarn storybook`.
+- 1.5.0: Reintroduced environment toggles so the React manager only composes Angular/Vue refs when explicitly enabled.

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -24,6 +24,28 @@ const getRefMode = () => {
 const refMode = getRefMode();
 const isStaticRefMode = refMode === "static";
 
+const parseEnvToggle = (value: string | undefined, defaultValue: boolean) => {
+  if (value === undefined) {
+    return defaultValue;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (["false", "0", "off", "no"].includes(normalized)) {
+    return false;
+  }
+  if (["true", "1", "on", "yes"].includes(normalized)) {
+    return true;
+  }
+
+  return defaultValue;
+};
+
+const composeAngular = parseEnvToggle(
+  process.env.STORYBOOK_COMPOSE_ANGULAR,
+  true,
+);
+const composeVue = parseEnvToggle(process.env.STORYBOOK_COMPOSE_VUE, true);
+
 const reactDevUrl =
   process.env.STORYBOOK_REACT_URL ?? "http://localhost:6006";
 const angularDevUrl =
@@ -40,14 +62,22 @@ export const refs: StorybookConfig["refs"] = {
     title: "React",
     url: isStaticRefMode ? reactStaticUrl : reactDevUrl,
   },
-  angular: {
-    title: "Angular",
-    url: isStaticRefMode ? angularStaticUrl : angularDevUrl,
-  },
-  vue: {
-    title: "Vue",
-    url: isStaticRefMode ? vueStaticUrl : vueDevUrl,
-  },
+  ...(composeAngular
+    ? {
+        angular: {
+          title: "Angular",
+          url: isStaticRefMode ? angularStaticUrl : angularDevUrl,
+        },
+      }
+    : {}),
+  ...(composeVue
+    ? {
+        vue: {
+          title: "Vue",
+          url: isStaticRefMode ? vueStaticUrl : vueDevUrl,
+        },
+      }
+    : {}),
 };
 
 const config: StorybookConfig = {

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ If you need to focus on the React workspace alone, run:
 yarn storybook:react
 ```
 
+This command disables the Angular and Vue refs by default. Opt back into composition by setting the `STORYBOOK_COMPOSE_ANGULAR` and `STORYBOOK_COMPOSE_VUE` environment variables to `true` when invoking the script.
+
 Build the component package (production output):
 
 ```bash
@@ -82,6 +84,9 @@ STORYBOOK_ANGULAR_URL="https://design-system-angular.example.com" yarn storybook
 
 # Override the Vue ref (defaults to http://localhost:6008)
 STORYBOOK_VUE_URL="https://design-system-vue.example.com" yarn storybook
+
+# Opt back into composition while using `yarn storybook:react`
+STORYBOOK_COMPOSE_ANGULAR=true STORYBOOK_COMPOSE_VUE=true yarn storybook:react
 ```
 
 ## Scripts

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "version": "changeset version",
     "release": "changeset publish",
     "verify:agents": "node scripts/verify-agents-version.mjs",
-    "storybook:react": "cross-env STORYBOOK_REF_MODE=dev storybook dev -p 6006",
+    "storybook:react": "cross-env STORYBOOK_REF_MODE=dev STORYBOOK_COMPOSE_ANGULAR=false STORYBOOK_COMPOSE_VUE=false storybook dev -p 6006",
     "prestorybook:react": "yarn run generate:tokens",
     "storybook:angular": "cross-env STORYBOOK_REF_MODE=dev NG_CLI_ANALYTICS=false ng run design-system-storybook:start-storybook --port 6007 --ci",
     "prestorybook:angular": "yarn run generate:tokens",


### PR DESCRIPTION
## Summary
- gate the Angular and Vue Storybook refs behind environment toggles so the React manager only composes when requested
- default the React-only dev script to disable external refs and document the new switches for contributors
- record a patch changeset for the Storybook tooling adjustment

## Testing
- yarn storybook *(fails: attempts to spawn xdg-open in the container)*
- yarn storybook:react *(fails: attempts to spawn xdg-open in the container)*
- yarn generate:icons
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68dee17f8694832c83ab7f921afb8cc8