### PR TITLE
Stop composing React ref in Storybook manager

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -46,22 +46,15 @@ const composeAngular = parseEnvToggle(
 );
 const composeVue = parseEnvToggle(process.env.STORYBOOK_COMPOSE_VUE, true);
 
-const reactDevUrl =
-  process.env.STORYBOOK_REACT_URL ?? "http://localhost:6006";
 const angularDevUrl =
   process.env.STORYBOOK_ANGULAR_URL ?? "http://localhost:6007"; // Override STORYBOOK_ANGULAR_URL to point at a remote Angular Storybook.
 const vueDevUrl =
   process.env.STORYBOOK_VUE_URL ?? "http://localhost:6008"; // Override STORYBOOK_VUE_URL to point at a remote Vue Storybook.
-const reactStaticUrl = process.env.STORYBOOK_REACT_STATIC_URL ?? "./";
 const angularStaticUrl =
   process.env.STORYBOOK_ANGULAR_STATIC_URL ?? "./angular";
 const vueStaticUrl = process.env.STORYBOOK_VUE_STATIC_URL ?? "./vue";
 
 export const refs: StorybookConfig["refs"] = {
-  react: {
-    title: "React",
-    url: isStaticRefMode ? reactStaticUrl : reactDevUrl,
-  },
   ...(composeAngular
     ? {
         angular: {


### PR DESCRIPTION
## Summary
- remove the self-referential React entry from the Storybook `refs` map
- leave Angular and Vue refs conditional on their environment toggles so the manager loads local React stories

## Testing
- CI=1 yarn storybook *(fails: Angular workspace requires builder migration)*
- yarn build-storybook
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68df8b4412ec832c9f0ccb84122ec6e9