### PR TITLE
Add CORS headers for Angular and Vue Storybook refs

### DIFF
--- a/.changeset/cors-headers-storybook.md
+++ b/.changeset/cors-headers-storybook.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Add CORS headers to Angular and Vue Storybook refs so the React manager can load their stories without sidebar errors.

--- a/storybooks/angular/.storybook/main.ts
+++ b/storybooks/angular/.storybook/main.ts
@@ -34,11 +34,21 @@ const config: StorybookConfig = {
       },
     };
 
+    const serverConfig = {
+      ...(config.server ?? {}),
+      headers: {
+        ...(config.server?.headers ?? {}),
+        "Access-Control-Allow-Origin": "http://localhost:6006",
+        "Access-Control-Allow-Credentials": "true",
+      },
+    };
+
     if (configType === "PRODUCTION") {
       return {
         ...config,
         base: "./",
         resolve: resolveConfig,
+        server: serverConfig,
         plugins: [
           ...(config.plugins ?? []),
           {
@@ -58,7 +68,7 @@ const config: StorybookConfig = {
       ...config,
       resolve: resolveConfig,
       server: {
-        ...(config.server ?? {}),
+        ...serverConfig,
         watch: {
           usePolling: true,
           interval: 200,

--- a/storybooks/angular/AGENTS.md
+++ b/storybooks/angular/AGENTS.md
@@ -12,3 +12,4 @@ This workspace inherits the repository root and `storybooks/AGENTS.md` guidance.
 - 1.3.0: Normalized the HTML transform hook to plain JavaScript so the composed Storybook build succeeds.
 - 1.4.0: Adopted the Angular CLI Storybook builders (start/build) via `ng run` to satisfy the SB 9 migration checks.
 - 1.5.0: Migrated the Angular Storybook workspace to the Vite builder and aligned the scripts with the React/Vue setups.
+- 1.5.1: Added CORS headers to the Vite dev server so React can compose the Angular ref without sidebar errors.

--- a/storybooks/vue/.storybook/main.ts
+++ b/storybooks/vue/.storybook/main.ts
@@ -30,11 +30,21 @@ const config: StorybookConfig = {
       },
     };
 
+    const serverConfig = {
+      ...(config.server ?? {}),
+      headers: {
+        ...(config.server?.headers ?? {}),
+        "Access-Control-Allow-Origin": "http://localhost:6006",
+        "Access-Control-Allow-Credentials": "true",
+      },
+    };
+
     if (configType === "PRODUCTION") {
       return {
         ...config,
         base: "./",
         resolve: resolveConfig,
+        server: serverConfig,
         plugins: [
           ...(config.plugins ?? []),
           {
@@ -54,7 +64,7 @@ const config: StorybookConfig = {
       ...config,
       resolve: resolveConfig,
       server: {
-        ...(config.server ?? {}),
+        ...serverConfig,
         watch: {
           usePolling: true,
           interval: 200,

--- a/storybooks/vue/AGENTS.md
+++ b/storybooks/vue/AGENTS.md
@@ -9,3 +9,4 @@ This workspace inherits the repository root and `storybooks/AGENTS.md` guidance.
 
 ## Functional Changes
 - 1.3.0: Introduced the Vue Storybook workspace with shared theming, configuration, and placeholder button stories.
+- 1.3.1: Added CORS headers to the Vite dev server so React can consume the Vue ref without sidebar errors.


### PR DESCRIPTION
## Summary
- add shared Access-Control headers in the Vue and Angular Storybook `viteFinal` hooks so the React manager can load their refs
- record the Storybook ref change in the Angular and Vue `AGENTS.md` logs
- add a changeset documenting the Storybook tooling update

## Testing
- yarn generate:icons
- yarn storybook *(each workspace started, then the command exited when Storybook attempted to spawn `xdg-open` in the container)*
- yarn build-storybook
- yarn build
- yarn test


------
https://chatgpt.com/codex/tasks/task_e_68df9c3b5f4c832ca564afa18a068830