### PR TITLE
fix: expand Angular Storybook allow-list

### DIFF
--- a/.changeset/angular-storybook-allowlist.md
+++ b/.changeset/angular-storybook-allowlist.md
@@ -1,0 +1,4 @@
+---
+"design-system-icons": patch
+---
+Ensure the Angular Storybook dev server allow-list covers the workspace root to avoid 403 errors when loading stories.

--- a/storybooks/angular/.storybook/AGENTS.md
+++ b/storybooks/angular/.storybook/AGENTS.md
@@ -10,3 +10,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 - 1.2.0: Added Storybook 9 Angular configuration with shared Vite aliases and production base handling.
 - 1.5.0: Switched the Angular Storybook config to `viteFinal` with shared server and production tweaks.
 - 1.5.2: Added the Angular Vite plugin loader to ensure internal Angular packages compile in Storybook.
+- 1.5.3: Expanded the Vite dev server allow-list to cover the Angular workspace root and prevent 403s.

--- a/storybooks/angular/.storybook/main.ts
+++ b/storybooks/angular/.storybook/main.ts
@@ -9,6 +9,7 @@ import type { StorybookConfig } from "@storybook/angular";
  */
 const storybookDir = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(storybookDir, "../../..");
+const angularWorkspaceRoot = resolve(storybookDir, "..");
 
 const resolveFromRoot = (relativePath: string) => resolve(repoRoot, relativePath);
 
@@ -40,6 +41,14 @@ const config: StorybookConfig = {
       },
     };
 
+    const allowList = Array.from(
+      new Set([
+        ...(config.server?.fs?.allow ?? []),
+        resolveFromRoot("src"),
+        angularWorkspaceRoot,
+      ]),
+    );
+
     const serverConfig = {
       ...(config.server ?? {}),
       headers: {
@@ -49,10 +58,7 @@ const config: StorybookConfig = {
       },
       fs: {
         ...(config.server?.fs ?? {}),
-        allow: [
-          ...(config.server?.fs?.allow ?? []),
-          resolveFromRoot("src"),
-        ],
+        allow: allowList,
       },
     };
 


### PR DESCRIPTION
## Summary
- include the Angular workspace root in the Storybook Vite allow-list while keeping existing entries de-duplicated
- document the configuration tweak in the Angular Storybook AGENTS guidance and add a changeset entry

## Testing
- yarn build
- yarn test
- CI=1 yarn storybook:angular
- curl -I http://localhost:6007/src/stories/Button.stories.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfaf1fcc78832cad18e28c0e2c2c70