### PR TITLE
Ensure Angular Storybook defines runtime options

### DIFF
--- a/.changeset/angular-storybook-options-define.md
+++ b/.changeset/angular-storybook-options-define.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Ensure Angular Storybook injects STORYBOOK_ANGULAR_OPTIONS through Vite define so runtime builds always receive framework options.

--- a/.changeset/angular-storybook-options-define.md
+++ b/.changeset/angular-storybook-options-define.md
@@ -2,4 +2,4 @@
 "design-system-icons": patch
 ---
 
-Ensure Angular Storybook injects STORYBOOK_ANGULAR_OPTIONS through Vite define so runtime builds always receive framework options.
+Ensure Angular Storybook injects STORYBOOK_ANGULAR_OPTIONS through Vite define so runtime builds always receive framework options and load Zone.js before Angular bootstraps.

--- a/.changeset/angular-storybook-options-define.md
+++ b/.changeset/angular-storybook-options-define.md
@@ -2,4 +2,4 @@
 "design-system-icons": patch
 ---
 
-Ensure Angular Storybook injects STORYBOOK_ANGULAR_OPTIONS through Vite define so runtime builds always receive framework options and load Zone.js before Angular bootstraps.
+Ensure Angular Storybook injects STORYBOOK_ANGULAR_OPTIONS through Vite define so runtime builds always receive framework options, load Zone.js before Angular bootstraps, and import the shared stylesheet so stories render with design system theming.

--- a/storybooks/angular/.storybook/AGENTS.md
+++ b/storybooks/angular/.storybook/AGENTS.md
@@ -12,3 +12,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 - 1.5.2: Added the Angular Vite plugin loader to ensure internal Angular packages compile in Storybook.
 - 1.5.3: Expanded the Vite dev server allow-list to cover the Angular workspace root and prevent 403s.
 - 1.5.4: Injected `STORYBOOK_ANGULAR_OPTIONS` via Vite `define` so Angular framework options propagate without runtime errors.
+- 1.5.5: Ensured the Angular Storybook runtime loads Zone.js and forwards `framework.options` to Vite so bootstrap works without NG0908.

--- a/storybooks/angular/.storybook/AGENTS.md
+++ b/storybooks/angular/.storybook/AGENTS.md
@@ -13,3 +13,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 - 1.5.3: Expanded the Vite dev server allow-list to cover the Angular workspace root and prevent 403s.
 - 1.5.4: Injected `STORYBOOK_ANGULAR_OPTIONS` via Vite `define` so Angular framework options propagate without runtime errors.
 - 1.5.5: Ensured the Angular Storybook runtime loads Zone.js and forwards `framework.options` to Vite so bootstrap works without NG0908.
+- 1.5.6: Imported the shared design system stylesheet into the preview to restore theming for Angular stories.

--- a/storybooks/angular/.storybook/AGENTS.md
+++ b/storybooks/angular/.storybook/AGENTS.md
@@ -11,3 +11,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 - 1.5.0: Switched the Angular Storybook config to `viteFinal` with shared server and production tweaks.
 - 1.5.2: Added the Angular Vite plugin loader to ensure internal Angular packages compile in Storybook.
 - 1.5.3: Expanded the Vite dev server allow-list to cover the Angular workspace root and prevent 403s.
+- 1.5.4: Injected `STORYBOOK_ANGULAR_OPTIONS` via Vite `define` so Angular framework options propagate without runtime errors.

--- a/storybooks/angular/.storybook/main.ts
+++ b/storybooks/angular/.storybook/main.ts
@@ -13,12 +13,14 @@ const angularWorkspaceRoot = resolve(storybookDir, "..");
 
 const resolveFromRoot = (relativePath: string) => resolve(repoRoot, relativePath);
 
+const angularFrameworkOptions: Record<string, unknown> = {};
+
 const config: StorybookConfig = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|jsx|mjs|ts|tsx)"],
   addons: ["@storybook/addon-docs", "@storybook/addon-a11y", "@storybook/addon-designs"],
   framework: {
     name: "@storybook/angular",
-    options: {},
+    options: angularFrameworkOptions,
   },
   core: {
     builder: "@storybook/builder-vite",
@@ -62,10 +64,16 @@ const config: StorybookConfig = {
       },
     };
 
+    const defineConfig = {
+      ...(config.define ?? {}),
+      STORYBOOK_ANGULAR_OPTIONS: JSON.stringify(angularFrameworkOptions),
+    };
+
     if (configType === "PRODUCTION") {
       return {
         ...config,
         base: "./",
+        define: defineConfig,
         resolve: resolveConfig,
         server: serverConfig,
         plugins: [
@@ -86,6 +94,7 @@ const config: StorybookConfig = {
 
     return {
       ...config,
+      define: defineConfig,
       resolve: resolveConfig,
       server: {
         ...serverConfig,

--- a/storybooks/angular/.storybook/preview.ts
+++ b/storybooks/angular/.storybook/preview.ts
@@ -1,3 +1,4 @@
+import "zone.js";
 import type { Preview } from "@storybook/angular";
 import {
   applyDesignTokenTheme,

--- a/storybooks/angular/.storybook/preview.ts
+++ b/storybooks/angular/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import "zone.js";
+import "../../../src/styles/index.css";
 import type { Preview } from "@storybook/angular";
 import {
   applyDesignTokenTheme,


### PR DESCRIPTION
## Summary
- ensure the Angular Storybook Vite config defines `STORYBOOK_ANGULAR_OPTIONS` using the framework options object
- record the configuration change in the Angular Storybook AGENTS change log
- add a changeset for the patch release

## Testing
- yarn generate:icons
- yarn build
- yarn test
- yarn storybook:angular --no-open

------
https://chatgpt.com/codex/tasks/task_e_68dfc1c18dd4832c92869842120b2a00