### PR TITLE
Add credentialed CORS support to Angular and Vue Storybooks

### DIFF
--- a/.changeset/gold-doors-happen.md
+++ b/.changeset/gold-doors-happen.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Ensure the Angular and Vue Storybook refs expose credentialed CORS responses for composed managers.

--- a/storybooks/angular/.storybook/AGENTS.md
+++ b/storybooks/angular/.storybook/AGENTS.md
@@ -14,3 +14,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 - 1.5.4: Injected `STORYBOOK_ANGULAR_OPTIONS` via Vite `define` so Angular framework options propagate without runtime errors.
 - 1.5.5: Ensured the Angular Storybook runtime loads Zone.js and forwards `framework.options` to Vite so bootstrap works without NG0908.
 - 1.5.6: Imported the shared design system stylesheet into the preview to restore theming for Angular stories.
+- 1.5.7: Enabled credentialed CORS handling in the Vite dev server while preserving Storybook defaults.

--- a/storybooks/angular/.storybook/main.ts
+++ b/storybooks/angular/.storybook/main.ts
@@ -56,6 +56,19 @@ const storybookConfig: StorybookConfig = {
       ]),
     );
 
+    const existingCors = viteConfig.server?.cors;
+    const corsConfig =
+      typeof existingCors === "object" && existingCors !== null
+        ? {
+            ...existingCors,
+            origin: true,
+            credentials: true,
+          }
+        : {
+            origin: true,
+            credentials: true,
+          };
+
     const serverConfig = {
       ...(viteConfig.server ?? {}),
       headers: {
@@ -63,6 +76,7 @@ const storybookConfig: StorybookConfig = {
         "Access-Control-Allow-Origin": "http://localhost:6006",
         "Access-Control-Allow-Credentials": "true",
       },
+      cors: corsConfig,
       fs: {
         ...(viteConfig.server?.fs ?? {}),
         allow: allowList,

--- a/storybooks/vue/.storybook/AGENTS.md
+++ b/storybooks/vue/.storybook/AGENTS.md
@@ -8,3 +8,4 @@ This directory inherits the repository root, `storybooks/AGENTS.md`, and `storyb
 
 ## Functional Changes
 - 1.3.0: Added Vue Storybook configuration powered by `@storybook/vue3-vite` with shared aliases and theming support.
+- 1.3.2: Enabled credentialed CORS handling in the Vite dev server without overriding Storybook defaults.

--- a/storybooks/vue/.storybook/main.ts
+++ b/storybooks/vue/.storybook/main.ts
@@ -30,6 +30,19 @@ const config: StorybookConfig = {
       },
     };
 
+    const existingCors = config.server?.cors;
+    const corsConfig =
+      typeof existingCors === "object" && existingCors !== null
+        ? {
+            ...existingCors,
+            origin: true,
+            credentials: true,
+          }
+        : {
+            origin: true,
+            credentials: true,
+          };
+
     const serverConfig = {
       ...(config.server ?? {}),
       headers: {
@@ -37,6 +50,7 @@ const config: StorybookConfig = {
         "Access-Control-Allow-Origin": "http://localhost:6006",
         "Access-Control-Allow-Credentials": "true",
       },
+      cors: corsConfig,
     };
 
     if (configType === "PRODUCTION") {


### PR DESCRIPTION
## Summary
- merge credentialed CORS configuration into the Angular and Vue Storybook Vite servers alongside existing headers and filesystem settings
- document the Storybook configuration change in the Angular and Vue `.storybook/AGENTS.md` files and record the release via a changeset

## Testing
- yarn build
- yarn test
- CI=1 yarn storybook

------
https://chatgpt.com/codex/tasks/task_e_68dfdaff0e00832c95e03106e7920916