### PR TITLE
Adjust Storybook compose startup ordering

### DIFF
--- a/.changeset/storybook-wait-for-refs.md
+++ b/.changeset/storybook-wait-for-refs.md
@@ -1,0 +1,4 @@
+---
+"design-system-icons": patch
+---
+Ensure the composed Storybook waits for Angular and Vue dev servers before launching the React manager.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ yarn generate:icons
 yarn generate:tokens
 ```
 
-Run the composed Storybook experience for React, Angular, and Vue on ports 6006/6007/6008:
+Run the composed Storybook experience for React, Angular, and Vue on ports 6006/6007/6008. The script boots the Angular and Vue
+dev servers first and waits for them to respond before composing the React manager so the tabs populate as soon as the window
+opens:
 
 ```bash
 yarn storybook
@@ -99,7 +101,8 @@ Commonly used scripts are listed below. Run them with `yarn <script>`.
 - `version` – Apply accumulated Changesets (`changeset version`) to bump `package.json`, changelogs, and generated release metadata (`yarn run version`).
 - `release` – Publish the release defined by Changesets (used by CI; requires `NPM_TOKEN`).
 - `verify:agents` – Ensure modified directories updated their `AGENTS.md` with a new semantic-version bullet (runs automatically in CI).
-- `storybook` – Launch the React, Angular, and Vue Storybook instances together (ports 6006/6007/6008) so refs resolve locally.
+- `storybook` – Launch the React, Angular, and Vue Storybook instances together (ports 6006/6007/6008). The script waits for the
+  Angular and Vue dev servers to report ready before composing the React manager so refs resolve locally.
 - `storybook:react` – Start the Storybook 9 (React + Vite) dev server with hot reload.
 - `storybook:react:compose` – Run the React manager with composition enabled (Angular/Vue refs) without booting the other dev servers.
 - `build-storybook` – Produce the static Storybook bundle and copy the Angular/Vue builds into `storybook-static/{angular,vue}` for composition.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -30,3 +30,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - 1.8.0: Documented Angular consumption patterns for the Button component alongside existing React and web component usage.
 - 1.9.0: Captured the multi-framework Storybook composition model, including build orchestration and local dev commands.
 - 1.10.0: Documented the `yarn storybook` workflow and remote ref overrides.
+- 1.11.0: Clarified that `yarn storybook` waits for Angular/Vue dev servers before composing the React manager.

--- a/docs/component-architecture.md
+++ b/docs/component-architecture.md
@@ -29,7 +29,10 @@ To determine whether a component should be authored as a web component or framew
 
 ## Multi-Framework Storybook Composition
 - The React workspace under `.storybook/` owns the primary manager and registers framework refs. Angular and Vue live in `storybooks/<framework>/.storybook` and expose their own build outputs.
-- Development: run `yarn storybook` to launch all three workspaces together. The script starts React on port 6006, Angular on 6007, and Vue on 6008 so the refs declared in `.storybook/main.ts` resolve to live dev servers when `STORYBOOK_REF_MODE=dev`. Override `STORYBOOK_ANGULAR_URL` or `STORYBOOK_VUE_URL` when pointing at remote builds.
+- Development: run `yarn storybook` to launch all three workspaces together. Angular (6007) and Vue (6008) boot first, and the
+  script waits for them to report ready before starting the React manager on 6006 so the refs declared in `.storybook/main.ts`
+  resolve to live dev servers when `STORYBOOK_REF_MODE=dev`. Override `STORYBOOK_ANGULAR_URL` or `STORYBOOK_VUE_URL` when pointing
+  at remote builds.
 - Static hosting: `yarn build-storybook` chains the Angular/Vue builds, runs the React build with `STORYBOOK_REF_MODE=static`, and copies the generated assets into `storybook-static/{angular,vue}` via `scripts/copy-storybook-refs.mjs`. The manager relies on the exported `refs` configuration so GitHub Pages (or any static host) serves the composed bundles without extra configuration.
 - Adding a new framework Storybook:
   1. Scaffold `storybooks/<framework>/.storybook/` with its own `main.ts` and `preview` configuration.

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -18,7 +18,9 @@ This document captures the current tooling, languages, and automation that power
 - Production builds adjust `base: './'`, rewrite the Vite mocker entry to support GitHub Pages hosting, and rely on Storybook refs so the Angular/Vue static bundles load from `storybook-static/{angular,vue}`.
 - Development server enables Vite polling (`usePolling: true`, `interval: 200`) to improve reliability on networked filesystems.
 - Multi-framework composition: the root `.storybook/main.ts` registers refs for React, Angular (`http://localhost:6007`), and Vue (`http://localhost:6008`) when `STORYBOOK_REF_MODE=dev`, and falls back to relative URLs during static builds. Override `STORYBOOK_ANGULAR_URL` or `STORYBOOK_VUE_URL` to point at remote Storybook deployments.
-- `yarn storybook` runs the React, Angular, and Vue workspaces together via `concurrently` so designers can switch between implementations from a single sidebar.
+- `yarn storybook` runs the React, Angular, and Vue workspaces together via `concurrently`, waiting on the Angular (6007) and Vue
+  (6008) dev servers before composing the React manager so designers can switch between implementations from a single sidebar as
+  soon as the UI loads.
 
 ## Icon Workflow
 1. **Optimization** – `yarn optimize-icons` runs `scripts/optimize-icons.mjs` to recursively optimize SVG files in `src/shared/assets/icons`, retaining `viewBox` attributes and replacing literal `fill`/`stroke` colors with `currentColor`.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "prestorybook:angular": "yarn run generate:tokens",
     "storybook:vue": "storybook dev -p 6008 -c storybooks/vue/.storybook",
     "prestorybook:vue": "yarn run generate:tokens",
-    "storybook": "concurrently --kill-others-on-fail --names react,angular,vue \"yarn storybook:react:compose\" \"yarn storybook:angular\" \"yarn storybook:vue\"",
+    "storybook": "concurrently --kill-others-on-fail --names angular,vue,react \"yarn storybook:angular\" \"yarn storybook:vue\" \"wait-on tcp:6007 tcp:6008 && yarn storybook:react:compose\"",
     "prestorybook": "yarn run generate:tokens",
     "build-storybook": "yarn run build-storybook:compose",
     "prebuild-storybook": "yarn run generate:icons && yarn run generate:tokens",
@@ -100,6 +100,7 @@
     "vite": "^6.2.5",
     "vitest": "^2.0.4",
     "vue": "^3.5.12",
+    "wait-on": "^7.2.0",
     "zone.js": "^0.14.7"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2953,6 +2953,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@hapi/hoek@npm:^9.0.0, @hapi/hoek@npm:^9.3.0":
+  version: 9.3.0
+  resolution: "@hapi/hoek@npm:9.3.0"
+  checksum: 10c0/a096063805051fb8bba4c947e293c664b05a32b47e13bc654c0dd43813a1cec993bdd8f29ceb838020299e1d0f89f68dc0d62a603c13c9cc8541963f0beca055
+  languageName: node
+  linkType: hard
+
+"@hapi/topo@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "@hapi/topo@npm:5.1.0"
+  dependencies:
+    "@hapi/hoek": "npm:^9.0.0"
+  checksum: 10c0/b16b06d9357947149e032bdf10151eb71aea8057c79c4046bf32393cb89d0d0f7ca501c40c0f7534a5ceca078de0700d2257ac855c15e59fe4e00bba2f25c86f
+  languageName: node
+  linkType: hard
+
 "@inquirer/ansi@npm:^1.0.0":
   version: 1.0.0
   resolution: "@inquirer/ansi@npm:1.0.0"
@@ -4771,6 +4787,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@sideway/address@npm:^4.1.5":
+  version: 4.1.5
+  resolution: "@sideway/address@npm:4.1.5"
+  dependencies:
+    "@hapi/hoek": "npm:^9.0.0"
+  checksum: 10c0/638eb6f7e7dba209053dd6c8da74d7cc995e2b791b97644d0303a7dd3119263bcb7225a4f6804d4db2bc4f96e5a9d262975a014f58eae4d1753c27cbc96ef959
+  languageName: node
+  linkType: hard
+
+"@sideway/formula@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "@sideway/formula@npm:3.0.1"
+  checksum: 10c0/3fe81fa9662efc076bf41612b060eb9b02e846ea4bea5bd114f1662b7f1541e9dedcf98aff0d24400bcb92f113964a50e0290b86e284edbdf6346fa9b7e2bf2c
+  languageName: node
+  linkType: hard
+
+"@sideway/pinpoint@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@sideway/pinpoint@npm:2.0.0"
+  checksum: 10c0/d2ca75dacaf69b8fc0bb8916a204e01def3105ee44d8be16c355e5f58189eb94039e15ce831f3d544f229889ccfa35562a0ce2516179f3a7ee1bbe0b71e55b36
+  languageName: node
+  linkType: hard
+
 "@sigstore/bundle@npm:^2.3.2":
   version: 2.3.2
   resolution: "@sigstore/bundle@npm:2.3.2"
@@ -6537,6 +6576,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"axios@npm:^1.6.1":
+  version: 1.12.2
+  resolution: "axios@npm:1.12.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.6"
+    form-data: "npm:^4.0.4"
+    proxy-from-env: "npm:^1.1.0"
+  checksum: 10c0/80b063e318cf05cd33a4d991cea0162f3573481946f9129efb7766f38fde4c061c34f41a93a9f9521f02b7c9565ccbc197c099b0186543ac84a24580017adfed
+  languageName: node
+  linkType: hard
+
 "babel-loader@npm:9.1.3":
   version: 9.1.3
   resolution: "babel-loader@npm:9.1.3"
@@ -7900,6 +7950,7 @@ __metadata:
     vite: "npm:^6.2.5"
     vitest: "npm:^2.0.4"
     vue: "npm:^3.5.12"
+    wait-on: "npm:^7.2.0"
     zone.js: "npm:^0.14.7"
   peerDependencies:
     "@angular/common": ">=18.0.0"
@@ -9047,7 +9098,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
+"follow-redirects@npm:^1.0.0, follow-redirects@npm:^1.15.6":
   version: 1.15.11
   resolution: "follow-redirects@npm:1.15.11"
   peerDependenciesMeta:
@@ -9099,7 +9150,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
+"form-data@npm:^4.0.0, form-data@npm:^4.0.4":
   version: 4.0.4
   resolution: "form-data@npm:4.0.4"
   dependencies:
@@ -10260,6 +10311,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"joi@npm:^17.11.0":
+  version: 17.13.3
+  resolution: "joi@npm:17.13.3"
+  dependencies:
+    "@hapi/hoek": "npm:^9.3.0"
+    "@hapi/topo": "npm:^5.1.0"
+    "@sideway/address": "npm:^4.1.5"
+    "@sideway/formula": "npm:^3.0.1"
+    "@sideway/pinpoint": "npm:^2.0.0"
+  checksum: 10c0/9262aef1da3f1bec5b03caf50c46368899fe03b8ff26cbe3d53af4584dd1049079fc97230bbf1500b6149db7cc765b9ee45f0deb24bb6fc3fa06229d7148c17f
+  languageName: node
+  linkType: hard
+
 "joycon@npm:^3.1.1":
   version: 3.1.1
   resolution: "joycon@npm:3.1.1"
@@ -11190,7 +11254,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimist@npm:^1.2.6":
+"minimist@npm:^1.2.6, minimist@npm:^1.2.8":
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 10c0/19d3fcdca050087b84c2029841a093691a91259a47def2f18222f41e7645a0b7c44ef4b40e88a1e58a40c84d2ef0ee6047c55594d298146d0eb3f6b737c20ce6
@@ -12746,6 +12810,13 @@ __metadata:
     forwarded: "npm:0.2.0"
     ipaddr.js: "npm:1.9.1"
   checksum: 10c0/c3eed999781a35f7fd935f398b6d8920b6fb00bbc14287bc6de78128ccc1a02c89b95b56742bf7cf0362cc333c61d138532049c7dedc7a328ef13343eff81210
+  languageName: node
+  linkType: hard
+
+"proxy-from-env@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "proxy-from-env@npm:1.1.0"
+  checksum: 10c0/fe7dd8b1bdbbbea18d1459107729c3e4a2243ca870d26d34c2c1bcd3e4425b7bcc5112362df2d93cc7fb9746f6142b5e272fd1cc5c86ddf8580175186f6ad42b
   languageName: node
   linkType: hard
 
@@ -15787,6 +15858,21 @@ __metadata:
   dependencies:
     xml-name-validator: "npm:^5.0.0"
   checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
+  languageName: node
+  linkType: hard
+
+"wait-on@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "wait-on@npm:7.2.0"
+  dependencies:
+    axios: "npm:^1.6.1"
+    joi: "npm:^17.11.0"
+    lodash: "npm:^4.17.21"
+    minimist: "npm:^1.2.8"
+    rxjs: "npm:^7.8.1"
+  bin:
+    wait-on: bin/wait-on
+  checksum: 10c0/1eff2189b3e4b0975889f3e480c75ca2a0d4275072779a6329e7cae8b729620594aa044509ddd89967de6ab2162169501b67b8d9562c16cac517837ffce17337
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- gate `yarn storybook` so Angular and Vue dev servers start before the React manager by adding `wait-on`
- document the new startup flow across the README and architecture/tech stack guides and log the docs change in `docs/AGENTS.md`
- add a changeset capturing the Storybook workflow adjustment

## Testing
- yarn generate:icons
- yarn build
- yarn test
- yarn storybook

------
https://chatgpt.com/codex/tasks/task_e_68dfe7e34414832c87d1649d7c4bf367