### PR TITLE
fix: enable full compilation mode for Angular Storybook

### DIFF
--- a/storybooks/angular/AGENTS.md
+++ b/storybooks/angular/AGENTS.md
@@ -14,3 +14,4 @@ This workspace inherits the repository root and `storybooks/AGENTS.md` guidance.
 - 1.5.0: Migrated the Angular Storybook workspace to the Vite builder and aligned the scripts with the React/Vue setups.
 - 1.5.1: Added CORS headers to the Vite dev server so React can compose the Angular ref without sidebar errors.
 - 1.5.2: Wired the Angular Vite plugin and dev server allow-list so internal Angular packages load in Storybook.
+- 1.5.3: Forced the Storybook TypeScript config into full AOT mode so Ivy metadata is emitted without JIT during static builds.

--- a/storybooks/angular/tsconfig.storybook.json
+++ b/storybooks/angular/tsconfig.storybook.json
@@ -18,6 +18,12 @@
       "@internal/angular/*": ["src/angular/*"]
     }
   },
+  "angularCompilerOptions": {
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true,
+    "compilationMode": "full"
+  },
   "include": [
     "../../src/angular/**/*.ts",
     "../../src/components/**/*.ts",


### PR DESCRIPTION
## Summary
- set the Angular Storybook tsconfig to use full compilation mode so static builds emit Ivy metadata without JIT
- document the compilation-mode adjustment in the Angular Storybook workspace change log

## Testing
- yarn build-storybook:angular
- yarn build-storybook
- yarn build
- yarn test

------
https://chatgpt.com/codex/tasks/task_e_68e013d5047c832c84f4114c53af7584