### PR TITLE
Fix Icon token sizing to respect CSS variables

### DIFF
--- a/.changeset/slow-tables-shop.md
+++ b/.changeset/slow-tables-shop.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Fix Icon token sizing to rely on CSS custom properties when size props use tokens.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -25,3 +25,4 @@ This document extends the root-level `AGENTS.md`. All contributors must read and
 - 1.8.0: Shared button tokens now power the Angular adapter exported from `src/angular/`.
 - 1.8.2: Exposed the Angular-owned button styles through a components barrel so React and custom elements import them via the `@components` alias.
 - 1.8.3: Swapped Storybook story typings to the `@storybook/react-vite` framework package after the automigration.
+- 1.8.4: Updated the Icon component to merge CSS token sizes into inline styles, added tests, and expanded stories to demonstrate token-driven sizing overrides.

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -130,6 +130,54 @@ export const Sizes: Story = {
   },
 };
 
+export const TokenOverride: Story = {
+  args: {
+    name: defaultIcon,
+    variant: "outline",
+    color: "var(--textPrimaryInteractive)",
+  },
+  render: (args) => (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        gap: "calc(var(--spacingM) * 1px)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "calc(var(--spacingS) * 1px)",
+          "--icon-size": "var(--iconsizesL)",
+        } as React.CSSProperties}
+      >
+        <span style={{ fontSize: "0.875rem" }}>Default token</span>
+        <Icon {...args} size="var(--icon-size)" />
+      </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "calc(var(--spacingS) * 1px)",
+          "--icon-size": "48px",
+        } as React.CSSProperties}
+      >
+        <span style={{ fontSize: "0.875rem" }}>Overridden to 48px</span>
+        <Icon {...args} size="var(--icon-size)" />
+      </div>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows how CSS custom properties can drive icon sizing. Each row reuses the same '--icon-size' token while the wrapper adjusts its value.",
+      },
+    },
+  },
+};
+
 export const Colors: Story = {
   args: {
     name: defaultIcon,

--- a/src/components/Icon/Icon.tsx
+++ b/src/components/Icon/Icon.tsx
@@ -100,20 +100,37 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref) {
   };
 
   const computedSize = toPx(size);
+  const isTokenSize = typeof size === 'string';
+  const providedWidth = (svgProps as any).width;
+  const providedHeight = (svgProps as any).height;
+
+  const existingStyle = style as React.CSSProperties | undefined;
+  const mergedStyle: React.CSSProperties | undefined =
+    isTokenSize && computedSize
+      ? {
+          ...existingStyle,
+          ...(existingStyle?.width == null && providedWidth == null
+            ? { width: computedSize }
+            : {}),
+          ...(existingStyle?.height == null && providedHeight == null
+            ? { height: computedSize }
+            : {}),
+        }
+      : existingStyle;
 
   // Default to filled shapes for both variants to preserve
   // flattened outlines exported from design tools.
   const defaultFill = (svgProps as any).fill ?? 'currentColor';
 
   const baseSvgProps: React.SVGProps<SVGSVGElement> = {
-    width: (svgProps as any).width ?? computedSize,
-    height: (svgProps as any).height ?? computedSize,
+    width: providedWidth ?? (isTokenSize ? undefined : computedSize),
+    height: providedHeight ?? (isTokenSize ? undefined : computedSize),
     color,
     fill: defaultFill,
     viewBox: (viewBoxProp as any) ?? (svgProps as any).viewBox ?? DEFAULT_VIEWBOX,
     xmlns: 'http://www.w3.org/2000/svg',
     className,
-    style,
+    style: mergedStyle,
     ref: ref as any,
     ...(commonAriaProps as any),
   };
@@ -139,8 +156,8 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref) {
       const wrapperStyle: React.CSSProperties = {
         display: 'inline-block',
         lineHeight: 0,
-        width: baseSvgProps.width as any,
-        height: baseSvgProps.height as any,
+        ...(baseSvgProps.width ? { width: baseSvgProps.width as any } : {}),
+        ...(baseSvgProps.height ? { height: baseSvgProps.height as any } : {}),
         color: baseSvgProps.color as any,
         ...(baseSvgProps.style || {}),
       };
@@ -171,8 +188,8 @@ const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(props, ref) {
       const wrapperStyle: React.CSSProperties = {
         display: 'inline-block',
         lineHeight: 0,
-        width: baseSvgProps.width as any,
-        height: baseSvgProps.height as any,
+        ...(baseSvgProps.width ? { width: baseSvgProps.width as any } : {}),
+        ...(baseSvgProps.height ? { height: baseSvgProps.height as any } : {}),
         color: baseSvgProps.color as any,
         ...(baseSvgProps.style || {}),
       };

--- a/src/components/Icon/__tests__/Icon.test.tsx
+++ b/src/components/Icon/__tests__/Icon.test.tsx
@@ -1,8 +1,47 @@
-import { describe, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 
-// Placeholder for Icon component unit tests.
-describe.skip('Icon', () => {
-  it('should render icons based on the generated map', () => {
-    // TODO: Implement after migrating Icon into framework-agnostic core.
+import { Icon } from '@components';
+
+const ICONS_MAP = {
+  example: 'M4 4h16v16H4z',
+};
+
+describe('Icon', () => {
+  it('applies numeric sizes via width and height attributes', () => {
+    const { getByLabelText } = render(
+      <Icon
+        name="example"
+        icons={ICONS_MAP}
+        size={32}
+        aria-label="Numeric sized icon"
+      />,
+    );
+
+    const svg = getByLabelText('Numeric sized icon');
+
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.getAttribute('width')).toBe('32px');
+    expect(svg.getAttribute('height')).toBe('32px');
+    expect(svg.getAttribute('style')).toBeNull();
+  });
+
+  it('merges token-driven size into inline styles when size is a CSS variable', () => {
+    const tokenSize = 'var(--iconsizesXl2)';
+    const { getByLabelText } = render(
+      <Icon
+        name="example"
+        icons={ICONS_MAP}
+        size={tokenSize}
+        aria-label="Token sized icon"
+      />,
+    );
+
+    const svg = getByLabelText('Token sized icon');
+
+    expect(svg.tagName.toLowerCase()).toBe('svg');
+    expect(svg.getAttribute('width')).toBeNull();
+    expect(svg.getAttribute('height')).toBeNull();
+    expect(svg).toHaveStyle({ width: tokenSize, height: tokenSize });
   });
 });


### PR DESCRIPTION
## Summary
- stop the Icon component from emitting width/height attributes when a CSS token string is passed and merge the computed size into inline styles instead
- add a token override story and Icon unit tests that cover numeric vs. token sizing
- document the Icon update in components/AGENTS.md and add a changeset for a patch release

## Testing
- yarn test --reporter=verbose
- yarn build-storybook
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e01b5b3d3c832c9f6348f2c460ea6d