### PR TITLE
Ensure Storybook artifacts bypass Jekyll

### DIFF
--- a/.changeset/nojekyll-storybook.md
+++ b/.changeset/nojekyll-storybook.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Ensure composed Storybook builds create a .nojekyll marker so Angular and Vue refs stay accessible on Pages.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -27,3 +27,4 @@ This file extends the repository root `AGENTS.md`. Always review the root conven
 - 1.3.0: Added a postbuild copy script to publish theme CSS and Google Sans font assets with each bundle.
 - 1.4.0: Extended the postbuild copy script to include the Angular distribution directory.
 - 1.5.0: Added `copy-storybook-refs.mjs` to sync Angular/Vue Storybook builds into the composed static output.
+- 1.6.0: Ensured composed Storybook copies emit a `.nojekyll` marker so framework JSON manifests serve correctly on Pages.

--- a/scripts/copy-storybook-refs.mjs
+++ b/scripts/copy-storybook-refs.mjs
@@ -1,4 +1,4 @@
-import { access, cp, mkdir, rm } from "node:fs/promises";
+import { access, cp, mkdir, rm, writeFile } from "node:fs/promises";
 import { constants } from "node:fs";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -55,6 +55,10 @@ const run = async () => {
   for (const framework of frameworks) {
     await copyFrameworkStorybook(framework);
   }
+
+  const noJekyllPath = join(staticDir, ".nojekyll");
+  await writeFile(noJekyllPath, "");
+  console.info(`[storybook][compose] Ensured ${noJekyllPath} exists`);
 };
 
 run().catch((error) => {


### PR DESCRIPTION
## Summary
- ensure the Storybook composition script writes a `.nojekyll` marker after copying Angular and Vue artifacts
- log the new expectation in the scripts AGENTS guide and capture the tooling change in a changeset

## Testing
- yarn generate:icons
- yarn build
- yarn test
- yarn build-storybook

------
https://chatgpt.com/codex/tasks/task_e_68e02b39330c832c99c220328513b2c3