### PR TITLE
Fix Angular Storybook button module metadata

### DIFF
--- a/.changeset/angular-storybook-module-metadata.md
+++ b/.changeset/angular-storybook-module-metadata.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Inline Angular Storybook button module metadata so <fivra-button> renders without NG0303 errors.

--- a/storybooks/AGENTS.md
+++ b/storybooks/AGENTS.md
@@ -8,3 +8,4 @@ This directory follows the repository root `AGENTS.md`. Use it to house framewor
 
 ## Functional Changes
 - 1.2.0: Added the Angular Storybook workspace with dedicated configuration and shared asset guidance.
+- 1.3.0: Documented the Angular button `moduleMetadata` fix to keep framework workspaces aligned.

--- a/storybooks/angular/AGENTS.md
+++ b/storybooks/angular/AGENTS.md
@@ -15,3 +15,4 @@ This workspace inherits the repository root and `storybooks/AGENTS.md` guidance.
 - 1.5.1: Added CORS headers to the Vite dev server so React can compose the Angular ref without sidebar errors.
 - 1.5.2: Wired the Angular Vite plugin and dev server allow-list so internal Angular packages load in Storybook.
 - 1.5.3: Forced the Storybook TypeScript config into full AOT mode so Ivy metadata is emitted without JIT during static builds.
+- 1.5.4: Routed button stories through an inline `moduleMetadata` helper so Angular modules register during Storybook renders.

--- a/storybooks/angular/src/stories/AGENTS.md
+++ b/storybooks/angular/src/stories/AGENTS.md
@@ -8,3 +8,4 @@ This directory inherits guidance from the repository root, `storybooks/AGENTS.md
 
 ## Functional Changes
 - 1.2.0: Added Angular Button stories that reuse shared styles and React-aligned controls.
+- 1.5.4: Ensured button stories supply `moduleMetadata` within the shared render helper so `<fivra-button>` loads without NG0303 errors.

--- a/storybooks/angular/src/stories/Button.stories.ts
+++ b/storybooks/angular/src/stories/Button.stories.ts
@@ -63,6 +63,10 @@ const defaultRender = (args: ButtonStoryArgs) => {
   const ariaLabel = ariaLabelOverride ?? rest.ariaLabel ?? null;
 
   return {
+    moduleMetadata: {
+      imports: [CommonModule, FivraButtonModule],
+      declarations: [FivraButtonComponent],
+    },
     props: {
       ...rest,
       style: style ?? null,


### PR DESCRIPTION
## Summary
- ensure the Angular button story render helper provides module metadata so `<fivra-button>` is declared when stories render
- keep the shared module decorator and document the Storybook fix in the Angular story AGENTS plus add a changeset entry

## Testing
- yarn test
- yarn build
- yarn build-storybook:angular
- yarn storybook:angular --no-open

------
https://chatgpt.com/codex/tasks/task_e_68e037e8cca4832c90321a8886f84c0e