### PR TITLE
Fix Angular Storybook button metadata imports

### DIFF
--- a/.changeset/angular-storybook-module-metadata.md
+++ b/.changeset/angular-storybook-module-metadata.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": patch
+---
+
+Inline Angular Storybook button module metadata so <fivra-button> renders without NG0303 errors and drop redundant decorators that reintroduced the warning.

--- a/storybooks/AGENTS.md
+++ b/storybooks/AGENTS.md
@@ -8,3 +8,5 @@ This directory follows the repository root `AGENTS.md`. Use it to house framewor
 
 ## Functional Changes
 - 1.2.0: Added the Angular Storybook workspace with dedicated configuration and shared asset guidance.
+- 1.3.0: Documented the Angular button `moduleMetadata` fix to keep framework workspaces aligned.
+- 1.3.1: Clarified that Angular stories embed their module imports via the shared render helper instead of relying on decorators.

--- a/storybooks/angular/AGENTS.md
+++ b/storybooks/angular/AGENTS.md
@@ -15,3 +15,5 @@ This workspace inherits the repository root and `storybooks/AGENTS.md` guidance.
 - 1.5.1: Added CORS headers to the Vite dev server so React can compose the Angular ref without sidebar errors.
 - 1.5.2: Wired the Angular Vite plugin and dev server allow-list so internal Angular packages load in Storybook.
 - 1.5.3: Forced the Storybook TypeScript config into full AOT mode so Ivy metadata is emitted without JIT during static builds.
+- 1.5.4: Routed button stories through an inline `moduleMetadata` helper so Angular modules register during Storybook renders.
+- 1.5.5: Simplified the button story metadata to only import `FivraButtonModule`, removing redundant decorators that caused NG0303 warnings.

--- a/storybooks/angular/src/stories/AGENTS.md
+++ b/storybooks/angular/src/stories/AGENTS.md
@@ -8,3 +8,5 @@ This directory inherits guidance from the repository root, `storybooks/AGENTS.md
 
 ## Functional Changes
 - 1.2.0: Added Angular Button stories that reuse shared styles and React-aligned controls.
+- 1.5.4: Ensured button stories supply `moduleMetadata` within the shared render helper so `<fivra-button>` loads without NG0303 errors.
+- 1.5.5: Removed redundant module decorators in favor of the render helper's imports to eliminate lingering NG0303 warnings.

--- a/storybooks/angular/src/stories/Button.stories.ts
+++ b/storybooks/angular/src/stories/Button.stories.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from "@angular/common";
 import type { Meta, StoryObj } from "@storybook/angular";
-import { moduleMetadata } from "@storybook/angular";
 
 import { FivraButtonComponent, FivraButtonModule } from "@internal/angular/button";
 import {
@@ -63,6 +62,9 @@ const defaultRender = (args: ButtonStoryArgs) => {
   const ariaLabel = ariaLabelOverride ?? rest.ariaLabel ?? null;
 
   return {
+    moduleMetadata: {
+      imports: [CommonModule, FivraButtonModule],
+    },
     props: {
       ...rest,
       style: style ?? null,
@@ -96,11 +98,6 @@ const meta: Meta<ButtonStoryArgs> = {
   title: "Components/Button/Angular",
   component: FivraButtonComponent,
   tags: ["autodocs"],
-  decorators: [
-    moduleMetadata({
-      imports: [CommonModule, FivraButtonModule],
-    }),
-  ],
   args: {
     children: "Button",
     variant: "primary",


### PR DESCRIPTION
## Summary
- drop the redundant Angular button story decorator so the render helper supplies the module imports
- document the streamlined Storybook metadata setup across the workspace AGENTS files and update the changeset description

## Testing
- yarn generate:icons
- yarn test
- yarn build
- yarn build-storybook:angular

------
https://chatgpt.com/codex/tasks/task_e_68e037e8cca4832c90321a8886f84c0e