### PR TITLE
fix: guard button story custom element registration

### DIFF
--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -23,3 +23,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.8.2: Added a components-level barrel that re-exports the Angular-owned button styles via `@components/Button/button.styles` so every adapter shares the same import path.
 - 1.8.3: Pointed the shared tests at the canonical Angular button styles to cover the inlined color-mix helper.
 - 1.8.4: Updated Button stories to import `Meta`/`StoryObj` from `@storybook/react-vite` so typings match the composed framework.
+- 1.8.5: React Storybook now imports `defineFivraButton()` from `@web-components` and guards duplicate registration in the custom element preview.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
+import { defineFivraButton } from "@web-components";
 
 const SEMANTIC_TONES = ["Success", "Warning", "Error"] as const;
 type SemanticTone = (typeof SEMANTIC_TONES)[number];
@@ -373,7 +374,9 @@ export const IconOnly: Story = {
 
 const WebComponentPreview: React.FC = () => {
   React.useEffect(() => {
-    defineFivraButton();
+    if (!customElements.get("fivra-button")) {
+      defineFivraButton();
+    }
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- import the button custom element registration helper into the React Storybook stories
- guard the storybook preview from re-registering the `<fivra-button>` element and log the change in the button AGENTS guide

## Testing
- yarn test
- yarn build
- yarn storybook:react

------
https://chatgpt.com/codex/tasks/task_e_68e0dff4fbf0832ca0dca55f25c94aa5