### PR TITLE
refactor: extract shared button story helpers

### DIFF
--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -24,3 +24,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.8.3: Pointed the shared tests at the canonical Angular button styles to cover the inlined color-mix helper.
 - 1.8.4: Updated Button stories to import `Meta`/`StoryObj` from `@storybook/react-vite` so typings match the composed framework.
 - 1.8.5: React Storybook now imports `defineFivraButton()` from `@web-components` and guards duplicate registration in the custom element preview.
+- 1.8.6: Extracted shared Storybook semantic style helpers for React and Angular button stories to keep palettes aligned.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -3,37 +3,17 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
+import {
+  SEMANTIC_TONES,
+  createButtonSemanticStyleFactories,
+} from "@components/Button/story-helpers";
 import { defineFivraButton } from "@web-components";
 
-const SEMANTIC_TONES = ["Success", "Warning", "Error"] as const;
-type SemanticTone = (typeof SEMANTIC_TONES)[number];
-
-const createPrimarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
-  ({
-    "--fivra-button-surface": `var(--backgroundPrimary${tone})`,
-    "--fivra-button-accent": `var(--backgroundPrimary${tone})`,
-    "--fivra-button-border": `var(--borderPrimary${tone})`,
-    "--fivra-button-text": "var(--backgroundNeutral0)",
-    "--fivra-button-hover-fallback": `var(--backgroundPrimary${tone})`,
-    "--fivra-button-active-fallback": `var(--backgroundPrimary${tone})`,
-  }) as React.CSSProperties;
-
-const createSecondarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
-  ({
-    "--fivra-button-accent": `var(--textPrimary${tone})`,
-    "--fivra-button-border": `var(--borderPrimary${tone})`,
-    "--fivra-button-text": `var(--textPrimary${tone})`,
-    "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
-    "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
-  }) as React.CSSProperties;
-
-const createTertiarySemanticStyles = (tone: SemanticTone): React.CSSProperties =>
-  ({
-    "--fivra-button-accent": `var(--textPrimary${tone})`,
-    "--fivra-button-text": `var(--textPrimary${tone})`,
-    "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
-    "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
-  }) as React.CSSProperties;
+const {
+  createPrimarySemanticStyles,
+  createSecondarySemanticStyles,
+  createTertiarySemanticStyles,
+} = createButtonSemanticStyleFactories<React.CSSProperties>((overrides) => overrides);
 
 const meta: Meta<typeof Button> = {
   title: "Components/Button/React",

--- a/src/components/Button/story-helpers.ts
+++ b/src/components/Button/story-helpers.ts
@@ -1,0 +1,56 @@
+export const SEMANTIC_TONES = ["Success", "Warning", "Error"] as const;
+
+export type SemanticTone = (typeof SEMANTIC_TONES)[number];
+
+export type SemanticStyleOverrides = Record<string, string>;
+
+export type SemanticStyleFactory<TStyles> = (tone: SemanticTone) => TStyles;
+
+export type ButtonSemanticStyleFactories<TStyles> = {
+  createPrimarySemanticStyles: SemanticStyleFactory<TStyles>;
+  createSecondarySemanticStyles: SemanticStyleFactory<TStyles>;
+  createTertiarySemanticStyles: SemanticStyleFactory<TStyles>;
+};
+
+const createPrimaryOverrides = (tone: SemanticTone): SemanticStyleOverrides => ({
+  "--fivra-button-surface": `var(--backgroundPrimary${tone})`,
+  "--fivra-button-accent": `var(--backgroundPrimary${tone})`,
+  "--fivra-button-border": `var(--borderPrimary${tone})`,
+  "--fivra-button-text": "var(--backgroundNeutral0)",
+  "--fivra-button-hover-fallback": `var(--backgroundPrimary${tone})`,
+  "--fivra-button-active-fallback": `var(--backgroundPrimary${tone})`,
+});
+
+const createSecondaryOverrides = (
+  tone: SemanticTone,
+): SemanticStyleOverrides => ({
+  "--fivra-button-accent": `var(--textPrimary${tone})`,
+  "--fivra-button-border": `var(--borderPrimary${tone})`,
+  "--fivra-button-text": `var(--textPrimary${tone})`,
+  "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
+  "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
+});
+
+const createTertiaryOverrides = (
+  tone: SemanticTone,
+): SemanticStyleOverrides => ({
+  "--fivra-button-accent": `var(--textPrimary${tone})`,
+  "--fivra-button-text": `var(--textPrimary${tone})`,
+  "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
+  "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
+});
+
+export function createButtonSemanticStyleFactories(): ButtonSemanticStyleFactories<SemanticStyleOverrides>;
+export function createButtonSemanticStyleFactories<TStyles>(
+  mapOverrides: (overrides: SemanticStyleOverrides) => TStyles,
+): ButtonSemanticStyleFactories<TStyles>;
+export function createButtonSemanticStyleFactories<TStyles>(
+  mapOverrides: (overrides: SemanticStyleOverrides) => TStyles = (overrides) =>
+    overrides as unknown as TStyles,
+): ButtonSemanticStyleFactories<TStyles> {
+  return {
+    createPrimarySemanticStyles: (tone) => mapOverrides(createPrimaryOverrides(tone)),
+    createSecondarySemanticStyles: (tone) => mapOverrides(createSecondaryOverrides(tone)),
+    createTertiarySemanticStyles: (tone) => mapOverrides(createTertiaryOverrides(tone)),
+  };
+}

--- a/storybooks/angular/src/stories/AGENTS.md
+++ b/storybooks/angular/src/stories/AGENTS.md
@@ -9,3 +9,4 @@ This directory inherits guidance from the repository root, `storybooks/AGENTS.md
 ## Functional Changes
 - 1.2.0: Added Angular Button stories that reuse shared styles and React-aligned controls.
 - 1.5.4: Ensured button stories supply `moduleMetadata` within the shared render helper so `<fivra-button>` loads without NG0303 errors.
+- 1.5.5: Button stories now import shared semantic style factories from `src/components/Button/story-helpers.ts` to match React palettes.

--- a/storybooks/angular/src/stories/Button.stories.ts
+++ b/storybooks/angular/src/stories/Button.stories.ts
@@ -8,11 +8,18 @@ import {
   type ButtonVariant,
   ensureButtonStyles,
 } from "@components/Button/button.styles";
+import {
+  SEMANTIC_TONES,
+  createButtonSemanticStyleFactories,
+} from "@components/Button/story-helpers";
 
 ensureButtonStyles();
 
-const SEMANTIC_TONES = ["Success", "Warning", "Error"] as const;
-type SemanticTone = (typeof SEMANTIC_TONES)[number];
+const {
+  createPrimarySemanticStyles,
+  createSecondarySemanticStyles,
+  createTertiarySemanticStyles,
+} = createButtonSemanticStyleFactories<Record<string, string>>((overrides) => overrides);
 
 type ButtonStoryArgs = {
   children?: string;
@@ -33,30 +40,6 @@ type ButtonStoryArgs = {
   trailingIcon?: unknown;
   onClick?: (event: MouseEvent) => void;
 };
-
-const createPrimarySemanticStyles = (tone: SemanticTone): Record<string, string> => ({
-  "--fivra-button-surface": `var(--backgroundPrimary${tone})`,
-  "--fivra-button-accent": `var(--backgroundPrimary${tone})`,
-  "--fivra-button-border": `var(--borderPrimary${tone})`,
-  "--fivra-button-text": "var(--backgroundNeutral0)",
-  "--fivra-button-hover-fallback": `var(--backgroundPrimary${tone})`,
-  "--fivra-button-active-fallback": `var(--backgroundPrimary${tone})`,
-});
-
-const createSecondarySemanticStyles = (tone: SemanticTone): Record<string, string> => ({
-  "--fivra-button-accent": `var(--textPrimary${tone})`,
-  "--fivra-button-border": `var(--borderPrimary${tone})`,
-  "--fivra-button-text": `var(--textPrimary${tone})`,
-  "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
-  "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
-});
-
-const createTertiarySemanticStyles = (tone: SemanticTone): Record<string, string> => ({
-  "--fivra-button-accent": `var(--textPrimary${tone})`,
-  "--fivra-button-text": `var(--textPrimary${tone})`,
-  "--fivra-button-hover-fallback": `var(--backgroundSecondary${tone})`,
-  "--fivra-button-active-fallback": `var(--backgroundSecondary${tone})`,
-});
 
 const defaultRender = (args: ButtonStoryArgs) => {
   const { children, style, onClick, "aria-label": ariaLabelOverride, ...rest } = args;


### PR DESCRIPTION
## Summary
- add `story-helpers.ts` to centralize the semantic button palette overrides for stories
- update React and Angular button stories to consume the shared factories and maintain typed style mappings
- document the refactor in the Button component and Angular Storybook AGENTS logs

## Testing
- yarn generate:icons
- yarn build
- yarn test
- yarn storybook:react --no-open
- yarn storybook:angular --no-open

------
https://chatgpt.com/codex/tasks/task_e_68e0e1d2bfcc832cb3f92822e59d3979