### PR TITLE
Document button component contract

### DIFF
--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -12,3 +12,4 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 - 1.2.0: Documented tertiary styling, icon-only/dropdown/loading APIs, and new token references for the Button component.
 - 1.8.0: Added Angular usage guidance for the Button component, covering modules, directives, and template projection APIs.
 - 1.8.1: Cross-linked the Button docs to the component contract so updates stay synchronized across references.
+- 1.8.2: Noted canonical Storybook and visual test references in the Button contract for doc maintainers.

--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -11,3 +11,4 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 - 1.0: Authored the initial Button reference guide covering React and custom element usage.
 - 1.2.0: Documented tertiary styling, icon-only/dropdown/loading APIs, and new token references for the Button component.
 - 1.8.0: Added Angular usage guidance for the Button component, covering modules, directives, and template projection APIs.
+- 1.8.1: Cross-linked the Button docs to the component contract so updates stay synchronized across references.

--- a/docs/components/button.md
+++ b/docs/components/button.md
@@ -2,6 +2,8 @@
 
 The Button component exposes an accessible, themeable action trigger implemented both as a React component and as a standards-based custom element. Styles, variants, and sizing tokens are shared across targets so teams can mix frameworks without visual drift.
 
+Refer to the [Button component contract](../../src/components/Button/AGENTS.md#component-contract) for the authoritative list of variants, sizes, accessibility requirements, and framework-specific props. Update that contract alongside this page when behavior shifts.
+
 - Source: [`src/components/Button/Button.tsx`](../../src/components/Button/Button.tsx)
 - Stories: [`src/components/Button/Button.stories.tsx`](../../src/components/Button/Button.stories.tsx)
 - Custom element: [`src/web-components/button.ts`](../../src/web-components/button.ts)

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -6,6 +6,95 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - Mirror any API changes in the accompanying Storybook stories, tests, and documentation during the same change.
 - Update the "Functional Changes" section below with a short note when behavior or public API changes.
 
+## Component Contract
+
+### Variants
+
+| Variant | Description | Token hooks |
+| --- | --- | --- |
+| `primary` | High-emphasis action with accent backgrounds, halo, and strong focus ring. | `--backgroundPrimaryInteractive`, `--textOnPrimary`, `--haloPrimary*` |
+| `secondary` | Neutral surface button with outlined emphasis and token-driven halo mix. | `--backgroundNeutral0`, `--borderNeutralStrong`, `--haloNeutral*` |
+| `tertiary` | Low-emphasis ghost button with transparent background and hover/active overlays. | `--overlayNeutral*`, `--textPrimaryInteractive` |
+
+### Sizes
+
+| Size | Description | Measurement hooks |
+| --- | --- | --- |
+| `sm` | Compact control for dense layouts, 32px height, 14px type, 8px horizontal padding. | `--buttonHeightSm`, `--buttonPaddingXSm`, `--iconSizeSm` |
+| `md` | Default control, 40px height, 16px type, 12px horizontal padding. | `--buttonHeightMd`, `--buttonPaddingXMd`, `--iconSizeMd` |
+| `lg` | Spacious control for marketing/forms, 48px height, 18px type, 16px horizontal padding. | `--buttonHeightLg`, `--buttonPaddingXLg`, `--iconSizeLg` |
+
+### Accessibility requirements
+
+- Every button must expose an accessible name via inner text, `aria-label`, or `aria-labelledby`.
+- Icon-only buttons set `iconOnly`/`icon-only` and **must** provide `aria-label`/`ariaLabel`.
+- Loading state toggles `aria-busy="true"` and disables pointer events.
+- Dropdown state appends `aria-haspopup="menu"` and sets `aria-expanded` when controlled.
+- Focus states rely on `:focus-visible` tokens and maintain 3:1 contrast for outlines.
+
+### Framework APIs
+
+#### React (`<Button />`)
+
+| Prop | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary'` | `'primary'` | Maps to variant tokens listed above. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Adjusts typography, padding, and icon spacing tokens. |
+| `fullWidth` | `boolean` | `false` | Sets `data-full-width` and expands to container width. |
+| `leadingIcon` | `React.ReactNode` | `undefined` | Rendered with `aria-hidden="true"` before the label. |
+| `trailingIcon` | `React.ReactNode` | `undefined` | Rendered with `aria-hidden="true"` after the label. |
+| `iconOnly` | `boolean` | `false` | Applies max radius and enforces accessible naming. |
+| `hasLabel` | `boolean` | `undefined` | Overrides automatic label detection when using visually hidden copy. |
+| `dropdown` | `boolean` | `false` | Adds caret indicator and toggles disclosure data attributes. |
+| `loading` | `boolean` | `false` | Shows spinner, sets `aria-busy`, and disables clicks. |
+| `...buttonProps` | `React.ButtonHTMLAttributes<HTMLButtonElement>` | – | Native button attributes (`type`, `disabled`, etc.). |
+
+#### Angular (`<fivra-button>`)
+
+| Input | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `'primary' \| 'secondary' \| 'tertiary'` | `'primary'` | Mirrors React variant behavior. |
+| `size` | `'sm' \| 'md' \| 'lg'` | `'md'` | Synchronizes spacing/typography tokens. |
+| `fullWidth` | `boolean` | `false` | Applies `data-full-width` and sets `display: block`. |
+| `iconOnly` | `boolean` | `false` | Requires `ariaLabel`/`ariaLabelledby`. |
+| `hasLabel` | `boolean` | `undefined` | Forces label detection for off-screen content. |
+| `dropdown` | `boolean` | `false` | Adds disclosure caret and `aria-haspopup`. |
+| `loading` | `boolean` | `false` | Shows spinner, disables host, and sets `ariaBusy`. |
+| `leadingIcon` | `TemplateRef<unknown>` | `undefined` | Projects template into leading slot. |
+| `trailingIcon` | `TemplateRef<unknown>` | `undefined` | Projects template into trailing slot. |
+| `type` | `'button' \| 'submit' \| 'reset'` | `'button'` | Proxies to internal `<button>` element. |
+| `disabled` | `boolean` | `false` | Disables the control and sets `ariaDisabled`. |
+| `ariaLabel` | `string` | `undefined` | Accessible name when no visual label is present. |
+| `ariaLabelledby` | `string` | `undefined` | References elements that label the button. |
+
+_Outputs_: `focus()` and `click()` methods proxy to the internal button for host bindings.
+
+#### Web component (`<fivra-button>`)
+
+| Attribute | Type | Default | Notes |
+| --- | --- | --- | --- |
+| `variant` | `primary \| secondary \| tertiary` | `primary` | Controls variant tokens. |
+| `size` | `sm \| md \| lg` | `md` | Adjusts size tokens. |
+| `full-width` | boolean attribute | `false` | Stretches to container width. |
+| `icon-only` | boolean attribute | `false` | Requires accessible name. |
+| `has-label` | boolean attribute | `false` | Forces label detection for hidden text. |
+| `dropdown` | boolean attribute | `false` | Adds disclosure caret and data attributes. |
+| `loading` | boolean attribute | `false` | Shows spinner, disables pointer events. |
+| `disabled` | boolean attribute | `false` | Reflects to internal button. |
+| `type` | `button \| submit \| reset` | `button` | Mirrors `HTMLButtonElement` defaulting behavior. |
+
+Slots: `leading-icon`, default, and `trailing-icon` provide icon/labelling parity with other frameworks. Methods `focus()`, `click()`, and `blur()` are forwarded to the internal button.
+
+### Canonical references
+
+- React stories: [`Button.stories.tsx`](./Button.stories.tsx)
+- React tests: [`__tests__/Button.test.tsx`](./__tests__/Button.test.tsx)
+- Angular implementation: [`../../angular/button/fivra-button.component.ts`](../../angular/button/fivra-button.component.ts)
+- Angular tests: [`../../angular/button/__tests__/fivra-button.component.test.ts`](../../angular/button/__tests__/fivra-button.component.test.ts)
+- Web component: [`../../web-components/button.ts`](../../web-components/button.ts)
+- Web component tests: [`../../web-components/__tests__/button.test.ts`](../../web-components/__tests__/button.test.ts)
+- Documentation: [`../../docs/components/button.md`](../../docs/components/button.md)
+
 ## Functional Changes
 - Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
 - 1.0: Initial `Button` component authored as both a React component and custom element with shared styling.
@@ -25,3 +114,4 @@ This directory follows the repository and `src/components/` standards. Keep shar
 - 1.8.4: Updated Button stories to import `Meta`/`StoryObj` from `@storybook/react-vite` so typings match the composed framework.
 - 1.8.5: React Storybook now imports `defineFivraButton()` from `@web-components` and guards duplicate registration in the custom element preview.
 - 1.8.6: Extracted shared Storybook semantic style helpers for React and Angular button stories to keep palettes aligned.
+- 1.8.7: Documented the component contract, canonical references, and cross-linked the docs reference page for easier maintenance.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -85,14 +85,17 @@ _Outputs_: `focus()` and `click()` methods proxy to the internal button for host
 
 Slots: `leading-icon`, default, and `trailing-icon` provide icon/labelling parity with other frameworks. Methods `focus()`, `click()`, and `blur()` are forwarded to the internal button.
 
-### Canonical references
+-### Canonical references
 
 - React stories: [`Button.stories.tsx`](./Button.stories.tsx)
 - React tests: [`__tests__/Button.test.tsx`](./__tests__/Button.test.tsx)
+- Angular stories: [`../../storybooks/angular/src/stories/Button.stories.ts`](../../storybooks/angular/src/stories/Button.stories.ts)
 - Angular implementation: [`../../angular/button/fivra-button.component.ts`](../../angular/button/fivra-button.component.ts)
 - Angular tests: [`../../angular/button/__tests__/fivra-button.component.test.ts`](../../angular/button/__tests__/fivra-button.component.test.ts)
+- Vue preview stories: [`../../storybooks/vue/src/stories/Button.stories.ts`](../../storybooks/vue/src/stories/Button.stories.ts)
 - Web component: [`../../web-components/button.ts`](../../web-components/button.ts)
 - Web component tests: [`../../web-components/__tests__/button.test.ts`](../../web-components/__tests__/button.test.ts)
+- Visual regression tests: [`../../visual-tests/button.spec.ts`](../../visual-tests/button.spec.ts)
 - Documentation: [`../../docs/components/button.md`](../../docs/components/button.md)
 
 ## Functional Changes
@@ -115,3 +118,4 @@ Slots: `leading-icon`, default, and `trailing-icon` provide icon/labelling parit
 - 1.8.5: React Storybook now imports `defineFivraButton()` from `@web-components` and guards duplicate registration in the custom element preview.
 - 1.8.6: Extracted shared Storybook semantic style helpers for React and Angular button stories to keep palettes aligned.
 - 1.8.7: Documented the component contract, canonical references, and cross-linked the docs reference page for easier maintenance.
+- 1.8.8: Added Storybook (React/Angular/Vue) and Playwright visual regression references to the contract for update tracking.


### PR DESCRIPTION
## Summary
- document the button component contract in `src/components/Button/AGENTS.md`, including cross-framework props and canonical references
- link the button reference docs to the shared contract and log the documentation update in `docs/components/AGENTS.md`

## Testing
- yarn verify:agents

------
https://chatgpt.com/codex/tasks/task_e_68e0ebe80528832c833f549e0f9002f2