### PR TITLE
Wait for Storybook fonts before button visuals

### DIFF
--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -13,3 +13,4 @@ This directory extends the repository root `AGENTS.md`. Use Playwright-based vis
 - 1.0: Introduced Playwright-powered visual regression tests targeting the Button Storybook stories and committed baselines.
 - 1.1.0: Added Angular dropdown/loading stories to the button visual suite to guard harmonized caret/spinner behavior.
 - 1.1.1: Updated the harness to target Angular via JIT-enabled Storybook refs and captured dropdown/loading baselines.
+- 1.1.2: Wait for `document.fonts.ready` (plus a frame tick) before capturing button stories so Google Sans always applies; refresh baselines after Playwright browsers finish installing.

--- a/visual-tests/button.spec.ts
+++ b/visual-tests/button.spec.ts
@@ -42,6 +42,10 @@ async function loadStory(page: Page, story: StoryConfig) {
     document.body.style.margin = "0";
     document.documentElement.style.setProperty("color-scheme", "light");
   });
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  });
 }
 
 test.describe("Button visual regressions", () => {


### PR DESCRIPTION
## Summary
- ensure the button visual harness waits for Storybook to finish applying Google Sans fonts before screenshots
- document the determinism tweak in the visual testing change log

## Testing
- yarn build
- CI=1 yarn test
- yarn visual:test --update-snapshots *(fails: Playwright browser download is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11af41494832c93915cf4c5bc8f8d