### PR TITLE
Add Playwright visual artifacts reporting

### DIFF
--- a/.changeset/social-beans-shop.md
+++ b/.changeset/social-beans-shop.md
@@ -1,0 +1,3 @@
+---
+---
+Document Playwright artifact uploads for visual regressions.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,15 @@ jobs:
       - name: Run visual regression tests
         run: yarn visual:test
 
+      - name: Upload visual regression artifacts
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: visual-regression-artifacts
+          if-no-files-found: warn
+          path: |
+            playwright-report/
+            test-results/**
+
       - name: Build package
         run: yarn build

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,14 @@ export default defineConfig({
     "{snapshotDir}/{testFileDir}/{testFileName}-snapshots/{arg}{ext}",
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
-  reporter: process.env.CI ? [["list"], ["github"]] : "list",
+  reporter: process.env.CI
+    ? [
+        ["list"],
+        ["github"],
+        ["html", { outputFolder: "playwright-report", open: "never" }],
+      ]
+    : [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]],
+  outputDir: "test-results",
   timeout: 30_000,
   expect: {
     toHaveScreenshot: {

--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -9,6 +9,7 @@ This directory extends the repository root `AGENTS.md`. Use Playwright-based vis
 - Whenever a visual diff is expected, refresh every affected baseline before merging so shared snapshots pass locally and in CI.
 - Document any new scenarios covered here in the contributor docs so the team understands the workflow.
 - Record notable updates in the "Functional Changes" section below.
+- When CI surfaces a failing run, download the `visual-regression-artifacts` upload from the job summary. Extract it locally to inspect `playwright-report/index.html` for an aggregated view and review the `test-results/` folder for the `*-actual.png`, `*-expected.png`, and `*-diff.png` comparisons.
 
 ## Functional Changes
 - Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
@@ -17,3 +18,4 @@ This directory extends the repository root `AGENTS.md`. Use Playwright-based vis
 - 1.1.1: Updated the harness to target Angular via JIT-enabled Storybook refs and captured dropdown/loading baselines.
 - 1.1.2: Wait for `document.fonts.ready` (plus a frame tick) before capturing button stories so Google Sans always applies; refresh baselines after Playwright browsers finish installing.
 - 1.1.3: Dropped OS-specific filename suffixes, refreshed shared baselines, and documented the cross-platform workflow.
+- 1.1.4: Publish HTML reports and diff image bundles when Playwright visual tests fail so reviewers can audit regressions quickly.


### PR DESCRIPTION
## Summary
- add Playwright HTML reporting and explicit test output directories for the visual suite
- upload visual regression artifacts when CI detects failures to aid review
- document the new artifact workflow in the visual testing guidelines and record it in the change log

## Testing
- yarn test
- yarn build
- yarn visual:test # expected to fail to confirm diff artifacts

------
https://chatgpt.com/codex/tasks/task_e_68e12bb9c828832c8d900a78c72bcef2