### PR TITLE
Ensure Playwright downloads Chromium headless shell before visual tests

### DIFF
--- a/.changeset/chromium-headless-shell.md
+++ b/.changeset/chromium-headless-shell.md
@@ -1,0 +1,4 @@
+---
+"design-system-icons": patch
+---
+Ensure Playwright installs the full Chromium toolchain before running visual tests and remind contributors to refresh baselines after the download completes.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build-storybook:vue": "storybook build -c storybooks/vue/.storybook -o storybooks/vue/storybook-static",
     "prebuild-storybook:vue": "yarn run generate:icons && yarn run generate:tokens",
     "build-storybook:compose": "yarn run build-storybook:angular && yarn run build-storybook:vue && yarn run build-storybook:root && node scripts/copy-storybook-refs.mjs",
-    "previsual:test": "playwright install --with-deps chromium",
+    "previsual:test": "playwright install --with-deps chromium chromium-headless-shell",
     "visual:test": "yarn run build-storybook:compose && playwright test",
     "build": "tsup && yarn build:angular && node scripts/copy-static-assets.mjs",
     "prebuild": "yarn run generate:tokens",

--- a/visual-tests/AGENTS.md
+++ b/visual-tests/AGENTS.md
@@ -19,3 +19,4 @@ This directory extends the repository root `AGENTS.md`. Use Playwright-based vis
 - 1.1.2: Wait for `document.fonts.ready` (plus a frame tick) before capturing button stories so Google Sans always applies; refresh baselines after Playwright browsers finish installing.
 - 1.1.3: Dropped OS-specific filename suffixes, refreshed shared baselines, and documented the cross-platform workflow.
 - 1.1.4: Publish HTML reports and diff image bundles when Playwright visual tests fail so reviewers can audit regressions quickly.
+- 1.1.5: Require the full Chromium toolchain (including `chromium-headless-shell`) before running tests and remind contributors to refresh baselines after the install completes.


### PR DESCRIPTION
## Summary
- update the visual test pre-script to download the Chromium headless shell so Playwright launches successfully after cache clears
- document the expanded browser installation requirement in `visual-tests/AGENTS.md`
- add a changeset covering the tooling update

## Testing
- yarn visual:test
- yarn test
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e1582b5b08832cb4304eeadbbffa49