### PR TITLE
Retitle Icon stories to Atomics taxonomy

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Refer to `package.json` for the full list of scripts and watch the `docs/archite
 - Storybook 9 runs on Vite 5 with the `@storybook/react-vite` framework.
 - Accessibility, documentation, and design review workflows are supported via `@storybook/addon-a11y`, `@storybook/addon-docs`, and `@storybook/addon-designs`.
 - Production builds set `base: './'`, include a Vite transform to ensure assets resolve correctly on GitHub Pages deployments, and wire Storybook refs to static Angular/Vue directories for hosted composition.
-- The composed Angular (`http://localhost:6007`) and Vue (`http://localhost:6008`) workspaces surface under `Components/Button/{Angular,Vue}` in the sidebar when the refs are running.
+- The composed Angular (`http://localhost:6007`) and Vue (`http://localhost:6008`) workspaces surface under `Atomics/Button` in the sidebar when the refs are running, preserving parity with the React stories.
 - Icon galleries and component examples automatically consume the generated icon map; rerun `yarn generate:icons` when assets change.
 
 Visit the published Storybook (if available) to explore live components, or run the local command above to iterate on new work.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -32,3 +32,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - 1.10.0: Documented the `yarn storybook` workflow and remote ref overrides.
 - 1.11.0: Clarified that `yarn storybook` waits for Angular/Vue dev servers before composing the React manager.
 - 1.12.0: Documented the Playwright visual regression workflow and how to refresh Storybook baselines.
+- 1.12.1: Updated the Welcome overview to reference the Icon stories under the Atomics taxonomy.

--- a/docs/overview/Welcome.mdx
+++ b/docs/overview/Welcome.mdx
@@ -52,5 +52,5 @@ Notes:
 
 ## Explore
 
-- “Components/Icon/React” — usage and examples.
+- “Atomics/Icon” — usage and examples.
 - “Gallery/Icons” — browse/search all icons; click to copy an icon name.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -26,3 +26,4 @@ This document extends the root-level `AGENTS.md`. All contributors must read and
 - 1.8.2: Exposed the Angular-owned button styles through a components barrel so React and custom elements import them via the `@components` alias.
 - 1.8.3: Swapped Storybook story typings to the `@storybook/react-vite` framework package after the automigration.
 - 1.8.4: Updated the Icon component to merge CSS token sizes into inline styles, added tests, and expanded stories to demonstrate token-driven sizing overrides.
+- 1.9.3: Retitled the Icon stories to `Atomics/Icon` and assigned a React meta ID for Storybook composition alignment.

--- a/src/components/Button/AGENTS.md
+++ b/src/components/Button/AGENTS.md
@@ -121,3 +121,4 @@ Slots: `leading-icon`, default, and `trailing-icon` provide icon/labelling parit
 - 1.8.8: Added Storybook (React/Angular/Vue) and Playwright visual regression references to the contract for update tracking.
 - 1.9.0: Harmonized label detection, dropdown aria defaults, and cross-framework stories/tests to lock the shared button contract.
 - 1.9.1: Enabled Angular Storybook JIT builds and Playwright baselines so dropdown/loading coverage exercises the shared aria defaults.
+- 1.9.2: Retitled the Button stories to `Atomics/Button` and set explicit story IDs for cross-framework Storybook composition.

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -16,7 +16,8 @@ const {
 } = createButtonSemanticStyleFactories<React.CSSProperties>((overrides) => overrides);
 
 const meta: Meta<typeof Button> = {
-  title: "Components/Button/React",
+  title: "Atomics/Button",
+  id: "atomics-button-react",
   component: Button,
   tags: ["autodocs"],
   args: {

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -10,7 +10,8 @@ const defaultIcon = iconNames.includes("chevron-right")
   : iconNames[0] ?? "";
 
 const meta: Meta<typeof Icon> = {
-  title: "Components/Icon/React",
+  title: "Atomics/Icon",
+  id: "atomics-icon-react",
   component: Icon,
   tags: ["autodocs"],
   argTypes: {

--- a/storybooks/angular/src/stories/AGENTS.md
+++ b/storybooks/angular/src/stories/AGENTS.md
@@ -16,3 +16,4 @@ This directory inherits guidance from the repository root, `storybooks/AGENTS.md
 - 1.6.3: Patched the Angular stories to hide duplicate native markup when the `<fivra-button>` custom element is registered.
 - 1.6.4: Replaced the CSS shim with a DOM-level cleanup so Storybook prunes duplicate light DOM buttons once `<fivra-button>` is registered.
 - 1.6.5: Removed the Angular web component story and related light DOM cleanup shim after confirming the nested button regression persists upstream.
+- 1.6.6: Updated Button stories to `Atomics/Button` and assigned a stable meta ID so composed Storybook refs group correctly.

--- a/storybooks/angular/src/stories/Button.stories.ts
+++ b/storybooks/angular/src/stories/Button.stories.ts
@@ -189,7 +189,8 @@ const defaultRender = (args: ButtonStoryArgs) => {
 };
 
 const meta: Meta<ButtonStoryArgs> = {
-  title: "Components/Button/Angular",
+  title: "Atomics/Button",
+  id: "atomics-button-angular",
   component: FivraButtonComponent,
   tags: ["autodocs"],
   decorators: [

--- a/storybooks/vue/src/stories/AGENTS.md
+++ b/storybooks/vue/src/stories/AGENTS.md
@@ -11,3 +11,4 @@ This directory inherits guidance from the repository root, `storybooks/AGENTS.md
 - 1.4.0: Extended placeholder stories with dropdown coverage, aria fallback messaging, and updated props to mirror the harmonized button contract.
 - 1.4.1: Mirrored the Angular/React controls for `ariaHaspopup`/`ariaExpanded` so the placeholder docs track the latest button contract.
 - 1.4.2: Replaced placeholder button stories with React-parity coverage, semantic helpers, and the web component preview.
+- 1.4.3: Updated Button stories to `Atomics/Button` with an explicit meta ID to align with the shared taxonomy and composed refs.

--- a/storybooks/vue/src/stories/Button.stories.ts
+++ b/storybooks/vue/src/stories/Button.stories.ts
@@ -215,7 +215,8 @@ const defaultRender = (args: VueButtonStoryArgs) => {
 };
 
 const meta: Meta<VueButtonStoryArgs> = {
-  title: "Components/Button/Vue",
+  title: "Atomics/Button",
+  id: "atomics-button-vue",
   component: FivraButtonPreview,
   tags: ["autodocs"],
   args: {

--- a/visual-tests/button.spec.ts
+++ b/visual-tests/button.spec.ts
@@ -8,21 +8,21 @@ type StoryConfig = {
 };
 
 const buttonStories: StoryConfig[] = [
-  { id: "components-button-react--primary", name: "primary" },
-  { id: "components-button-react--secondary", name: "secondary" },
-  { id: "components-button-react--tertiary", name: "tertiary" },
-  { id: "components-button-react--with-icons", name: "with-icons" },
-  { id: "components-button-react--dropdown", name: "dropdown" },
-  { id: "components-button-react--loading", name: "loading" },
-  { id: "components-button-react--icon-only", name: "icon-only" },
+  { id: "atomics-button-react--primary", name: "primary" },
+  { id: "atomics-button-react--secondary", name: "secondary" },
+  { id: "atomics-button-react--tertiary", name: "tertiary" },
+  { id: "atomics-button-react--with-icons", name: "with-icons" },
+  { id: "atomics-button-react--dropdown", name: "dropdown" },
+  { id: "atomics-button-react--loading", name: "loading" },
+  { id: "atomics-button-react--icon-only", name: "icon-only" },
   {
-    id: "components-button-angular--dropdown",
+    id: "atomics-button-angular--dropdown",
     name: "angular-dropdown",
     composePath: "angular",
     framework: "angular",
   },
   {
-    id: "components-button-angular--loading",
+    id: "atomics-button-angular--loading",
     name: "angular-loading",
     composePath: "angular",
     framework: "angular",


### PR DESCRIPTION
## Summary
- update the React Icon story meta to live under Atomics/Icon with a stable ID for composed Storybooks
- refresh the Welcome overview and directory change logs to reference the new Atomics taxonomy

## Testing
- yarn generate:icons
- yarn build
- CI=1 yarn test

------
https://chatgpt.com/codex/tasks/task_e_68e1998c0770832cbcfa3cbb65824d34