### PR TITLE
docs: collapse composite token rows

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -34,3 +34,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - 1.12.0: Documented the Playwright visual regression workflow and how to refresh Storybook baselines.
 - 1.12.1: Updated the Welcome overview to reference the Icon stories under the Atomics taxonomy.
 - 1.12.2: Documented the semantic tokens overview page and TokensTable specimen guidance sourced from generated tokens data.
+- 1.12.3: Collapsed typography and shadow composites in the TokensTable overview to show aggregated token rows and previews.

--- a/docs/overview/__tests__/TokensTable.test.ts
+++ b/docs/overview/__tests__/TokensTable.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRows } from '../TokensTable';
+
+describe('TokensTable composite rows', () => {
+  const rows = buildRows();
+
+  it('collapses typography composites into a single entry', () => {
+    const typographyRow = rows.find((row) => row.displayPath === 'typography.body-1');
+
+    expect(typographyRow).toBeDefined();
+    expect(typographyRow?.values.engage).toBeTypeOf('string');
+    expect(typographyRow?.values.engage).toMatch(/font-family:/);
+    expect(typographyRow?.alias).toContain('fontFamily');
+
+    const propertyRows = rows.filter((row) => row.path.join('.').startsWith('body-1.'));
+    expect(propertyRows).toHaveLength(0);
+  });
+
+  it('collapses shadow composites into a single entry', () => {
+    const shadowRow = rows.find((row) => row.displayPath?.startsWith('boxShadow.'));
+
+    expect(shadowRow).toBeDefined();
+    expect(shadowRow?.values.engage).toBeTypeOf('string');
+    expect(shadowRow?.values.engage).toMatch(/box-shadow:/);
+    expect(shadowRow?.alias).toContain('color');
+
+    const propertyRows = rows.filter((row) => row.path.join('.').startsWith('shadows.') && row.path.length > 2);
+    expect(propertyRows).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- collapse typography and shadow token rows into composite entries with aggregated alias and CSS value strings
- keep specimen rendering aligned to the merged composite metadata and show composite-friendly token labels
- add regression coverage around the composite rows and record the docs change in the directory log

## Testing
- yarn test --reporter=basic
- yarn build

------
https://chatgpt.com/codex/tasks/task_e_68e253c367f8832ca164fd0061e926df