### PR TITLE
docs: add integration placeholders and update figma meta

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -38,3 +38,4 @@ This document augments the root `AGENTS.md`. Ensure you understand the repositor
 - 1.12.4: Migrated the Tech Stack and Component Architecture narratives into Overview MDX pages and refreshed cross-links for the new locations.
 - 1.13.0: Reorganized Storybook docs into `Docs/Welcome`, `Docs/Overview/*`, and `Docs/Foundations/*`, aligning slugs and navigation with the new sidebar structure.
 - 1.13.1: Moved the Design Tokens reference, TokensTable specimen, and Icons Library story into `docs/foundations` for centralized foundations coverage.
+- 1.13.2: Added Chromatic and Tokens Studio integration placeholders and updated the Figma plugin documentation metadata.

--- a/docs/integrations/AGENTS.md
+++ b/docs/integrations/AGENTS.md
@@ -1,0 +1,12 @@
+# Integrations Documentation Guidelines
+
+This file extends the root `AGENTS.md` and `docs/AGENTS.md`. Follow those policies in addition to the integration-specific notes below.
+
+## Content Expectations
+- Keep integration guides focused on actionable setup steps, automation workflows, and cross-tool considerations.
+- Note any repository scripts, environment variables, or permission requirements that affect the integration.
+- Update placeholder pages promptly once integration details are finalized.
+
+## Functional Changes
+- Use `<major>.<minor>[.<patch>]` labels when recording updates.
+- 1.0.0: Added governance for integration docs, refreshed the Figma plugin meta title, and stubbed Chromatic and Tokens Studio guides.

--- a/docs/integrations/Chromatic.mdx
+++ b/docs/integrations/Chromatic.mdx
@@ -1,0 +1,7 @@
+import { Meta, Title } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Integrations/Chromatic (TBD)" />
+
+<Title>Chromatic (TBD)</Title>
+
+We are preparing integration instructions for Chromatic, including project linking, automated review workflows, and visual diff best practices. Stay tuned for the full guide.

--- a/docs/integrations/FigmaPlugin.mdx
+++ b/docs/integrations/FigmaPlugin.mdx
@@ -1,8 +1,8 @@
 import { Meta, Title } from '@storybook/addon-docs/blocks';
 
-<Meta title="Docs/Figma Plugin" />
+<Meta title="Docs/Integrations/Figma Plugin" />
 
-<Title>Figma Icon Exporter</Title>
+<Title>Figma Plugin</Title>
 
 This repository is designed to work hand‑in‑hand with the [Figma Icon Exporter](https://www.figma.com/community/plugin/1533548616572213704/figma-icon-exporter) plugin. The plugin automates exporting icons from Figma and opening a pull request in this repo with the updated SVG files.
 

--- a/docs/integrations/TokensStudio.mdx
+++ b/docs/integrations/TokensStudio.mdx
@@ -1,0 +1,7 @@
+import { Meta, Title } from '@storybook/addon-docs/blocks';
+
+<Meta title="Docs/Integrations/Tokens Studio (TBD)" />
+
+<Title>Tokens Studio (TBD)</Title>
+
+Detailed guidance for connecting Tokens Studio with the Fivra design system is coming soon. Check back for setup steps, sync workflows, and troubleshooting tips.


### PR DESCRIPTION
## Summary
- retitle the Figma plugin documentation to live under Docs/Integrations
- add placeholder Chromatic and Tokens Studio integration pages
- introduce governance for integrations docs and log the updates

## Testing
- yarn build
- yarn test
- yarn verify:agents

------
https://chatgpt.com/codex/tasks/task_e_68e27507b594832c8b27b2d009f6a84f