### PR TITLE
feat: add typography component

### DIFF
--- a/.changeset/typography-react.md
+++ b/.changeset/typography-react.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": minor
+---
+
+Add a token-backed React `Typography` primitive that injects shared styles, ships Storybook docs, and documents variant semantics for future framework adapters.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,4 +41,5 @@
 - 1.1.0: Documented the Changesets-powered release workflow, required `yarn changeset` for feature work, and enforced semantic-version bullets via `scripts/verify-agents-version.mjs`.
 - 1.1.1: Added a compose-friendly React Storybook script, refreshed README guidance, and noted the tooling alignment.
 - 1.2.0: Introduced Playwright-powered Storybook visual regression tests, CI coverage, and contributor guidance for managing baselines.
+- 1.3.0: Added the token-driven Typography primitive with documentation, tests, and governance updates for future framework adapters.
 

--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -13,3 +13,4 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 - 1.8.0: Added Angular usage guidance for the Button component, covering modules, directives, and template projection APIs.
 - 1.8.1: Cross-linked the Button docs to the component contract so updates stay synchronized across references.
 - 1.8.2: Noted canonical Storybook and visual test references in the Button contract for doc maintainers.
+- 1.9.0: Documented the Typography primitive, covering variant mapping, accessibility, and token references.

--- a/docs/components/typography.md
+++ b/docs/components/typography.md
@@ -1,0 +1,80 @@
+# Typography
+
+Typography exposes a token-backed text primitive that forwards semantic defaults, truncation helpers, and native HTML attributes. The React implementation centralizes CSS injection so Angular and Vue adapters can share the same custom properties without duplicating styles.
+
+Refer to the [Typography component contract](../../src/components/Typography/AGENTS.md#component-contract) for authoritative API details and cross-framework notes. Align updates here with Storybook examples and implementation changes.
+
+- Source: [`src/components/Typography/Typography.tsx`](../../src/components/Typography/Typography.tsx)
+- Styles: [`src/components/Typography/typography.styles.ts`](../../src/components/Typography/typography.styles.ts)
+- Stories: [`src/components/Typography/Typography.stories.tsx`](../../src/components/Typography/Typography.stories.tsx)
+
+## React usage
+
+```tsx
+import { Typography } from '@fivra/design-system';
+
+export function BillingSummary() {
+  return (
+    <section aria-labelledby="billing-heading">
+      <Typography id="billing-heading" variant="heading-2">
+        Billing summary
+      </Typography>
+      <Typography variant="body-2-long">
+        Charges settle on the first business day of each month. Updates apply to the next billing cycle.
+      </Typography>
+      <Typography variant="body-2-link" as="a" href="/billing/preferences">
+        Manage payment preferences
+      </Typography>
+    </section>
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Default | Description |
+| --- | --- | --- | --- |
+| `variant` | `TypographyVariant` | `'body-1'` | Maps text styling to Engage tokens (`--heading1FontSize`, `--body2LetterSpacing`, etc.). |
+| `truncate` | `boolean` | `false` | Adds `data-truncate="true"` to apply ellipsis overflow handling. |
+| `noWrap` | `boolean` | `false` | Prevents line wrapping by setting `white-space: nowrap` via `data-nowrap`. |
+| `as` | `React.ElementType` | Semantic default per variant | Overrides the rendered element. Headings default to `<h1>`–`<h3>`, body variants use `<p>`, and captions render `<span>`. |
+| `...typographyProps` | `React.ComponentPropsWithoutRef<T>` | – | Native attributes for the chosen element (e.g., `href` for anchors, `id`, `className`). |
+
+### Variants
+
+| Variant | Default element | Tokens |
+| --- | --- | --- |
+| `heading-1` | `<h1>` | `--heading1FontFamily`, `--heading1FontSize`, `--heading1FontWeight`, `--heading1LineHeight` |
+| `heading-2` | `<h2>` | `--heading2*` tokens |
+| `heading-3` | `<h3>` | `--heading3*` tokens |
+| `body-1` | `<p>` | `--body1*` tokens |
+| `body-1-medium` | `<p>` | `--body1Medium*` tokens |
+| `body-1-strong` | `<p>` | `--body1Strong*` tokens |
+| `body-2` | `<p>` | `--body2*` tokens |
+| `body-2-strong` | `<p>` | `--body2Strong*` tokens |
+| `body-2-link` | `<p>` | `--body2Link*` tokens and `--textPrimaryInteractive` color |
+| `body-2-long` | `<p>` | `--body2Long*` tokens |
+| `body-3` | `<p>` | `--body3*` tokens |
+| `caption-1` | `<span>` | `--caption1*` tokens |
+| `caption-1-strong` | `<span>` | `--caption1Strong*` tokens |
+
+## Accessibility
+
+- Headings default to semantic `<h1>`–`<h3>` elements so screen readers announce proper hierarchy. Override `as` when the document outline requires a different level.
+- Truncation applies `aria-hidden`-safe styling only; provide tooltips or expanded views when critical information is truncated.
+- Link-styled variants default to `<p>` to avoid empty anchors. Supply `as="a"` with an `href` when the copy represents an interactive link.
+
+## Theming
+
+The component reads Engage custom properties such as `--heading1FontFamily`, `--body2FontSize`, and `--textNeutral1`. Override these tokens at the theme or container scope to adjust typography across frameworks without changing component code.
+
+```css
+.marketing-theme {
+  --heading1FontSize: 32px;
+  --heading1FontWeight: 700;
+  --body2LetterSpacing: 0.02em;
+  --textNeutral1: #1c1932;
+}
+```
+
+Apply `.marketing-theme` to a container or root element to cascade new token values into Typography instances.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -27,3 +27,4 @@ This document extends the root-level `AGENTS.md`. All contributors must read and
 - 1.8.3: Swapped Storybook story typings to the `@storybook/react-vite` framework package after the automigration.
 - 1.8.4: Updated the Icon component to merge CSS token sizes into inline styles, added tests, and expanded stories to demonstrate token-driven sizing overrides.
 - 1.9.3: Retitled the Icon stories to `Atomics/Icon` and assigned a React meta ID for Storybook composition alignment.
+- 1.10.0: Introduced the token-backed React Typography primitive with shared style injector and cross-framework contract.

--- a/src/components/Typography/AGENTS.md
+++ b/src/components/Typography/AGENTS.md
@@ -1,0 +1,13 @@
+# Typography Component Guidelines
+
+This directory inherits the repository root `AGENTS.md` along with `src/components/AGENTS.md`. Follow those governance rules when updating implementation files, tests, stories, or documentation references tied to Typography.
+
+## Component Contract
+- Maintain the `Typography` primitive as a token-driven wrapper that maps variants to CSS custom properties defined in shared theme styles.
+- Keep the public API framework-agnostic: style helpers and variant typings should remain reusable by future Angular, Vue, or web component adapters.
+- Inject styles through `ensureTypographyStyles()` so consuming frameworks can opt into the same class- and data-attribute selectors without duplicating CSS.
+- Document variant defaults, accessibility expectations, and truncation behaviors within this file and the docs page to keep cross-framework parity.
+
+## Functional Changes
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0.0: Introduced the React `Typography` component with shared style injector, tests, and stories consuming Engage theme tokens.

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Typography } from '@components/Typography';
+import { TYPOGRAPHY_VARIANTS } from './typography.styles';
+
+const meta: Meta<typeof Typography> = {
+  title: 'Atomics/Typography',
+  id: 'atomics-typography-react',
+  component: Typography,
+  tags: ['autodocs'],
+  args: {
+    children: 'Fivra design tokens keep typography consistent across platforms.',
+    variant: 'body-1',
+  },
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: TYPOGRAPHY_VARIANTS,
+      description:
+        'Maps to Engage typography tokens (e.g., `--heading1FontSize`, `--body2LetterSpacing`).',
+    },
+    truncate: {
+      control: 'boolean',
+      description: 'Applies `text-overflow: ellipsis` and related data attributes for overflow handling.',
+      table: { category: 'Layout' },
+    },
+    noWrap: {
+      control: 'boolean',
+      description: 'Prevents wrapping without applying overflow truncation styles.',
+      table: { category: 'Layout' },
+    },
+    as: {
+      control: false,
+      description:
+        'Override the rendered element. Headings default to semantic `<h1>`–`<h3>` tags while body text renders paragraphs.',
+      table: { category: 'Accessibility' },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Token-backed typography primitive that forwards native text attributes while aligning React adapters with future Angular and Vue implementations.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Typography>;
+
+export const BodyCopy: Story = {
+  args: {
+    children:
+      'Use body variants for paragraphs, legal copy, and supporting descriptions. Engage tokens control font family, weight, and letter spacing.',
+    variant: 'body-1',
+  },
+};
+
+export const Headings: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 'calc(var(--spacingM) * 1px)' }}>
+      <Typography variant="heading-1">Heading 1</Typography>
+      <Typography variant="heading-2">Heading 2</Typography>
+      <Typography variant="heading-3">Heading 3</Typography>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Heading variants inherit semantic `<h1>`–`<h3>` elements by default so screen readers announce appropriate structure.',
+      },
+    },
+  },
+};
+
+export const EmphasisAndLinks: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 'calc(var(--spacingS) * 1px)' }}>
+      <Typography variant="body-1-strong">Body 1 strong emphasizes supporting copy.</Typography>
+      <Typography variant="body-2-strong">Body 2 strong with compact letter spacing.</Typography>
+      <Typography variant="body-2-link" as="a" href="#">
+        Body 2 link uses interactive tokens and can render as an anchor.
+      </Typography>
+      <Typography variant="caption-1">Caption 1 suits tertiary UI metadata.</Typography>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Typography variants remain token-sourced, enabling emphasis styles, link treatments, and captions without redefining CSS per framework.',
+      },
+    },
+  },
+};
+
+export const Truncation: Story = {
+  args: {
+    truncate: true,
+    children:
+      'When truncate is enabled this sentence will end with an ellipsis once the layout constrains its width beyond a single line of readable space.',
+    style: {
+      maxWidth: '220px',
+      display: 'block',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Toggle `truncate` to add ellipsis overflow handling. Combine with `noWrap` to prevent soft line breaks when truncation is not necessary.',
+      },
+    },
+  },
+};
+
+export const NoWrap: Story = {
+  args: {
+    noWrap: true,
+    children: 'No wrap keeps inline copy on a single line without trimming the text.',
+  },
+};

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -1,0 +1,107 @@
+import React, { forwardRef, useEffect } from 'react';
+
+import {
+  DEFAULT_TYPOGRAPHY_VARIANT,
+  TYPOGRAPHY_CLASS_NAME,
+  TYPOGRAPHY_VARIANTS,
+  type TypographyVariant,
+  ensureTypographyStyles,
+} from './typography.styles';
+
+type TypographyOwnProps = {
+  /** Visual variant mapped to design tokens. Defaults to `body-1`. */
+  variant?: TypographyVariant;
+  /** Truncates overflowing text with an ellipsis. */
+  truncate?: boolean;
+  /** Prevents line wrapping without truncation styling. */
+  noWrap?: boolean;
+  /** Override the rendered element. Defaults based on `variant`. */
+  as?: React.ElementType;
+  className?: string;
+  children?: React.ReactNode;
+};
+
+type PolymorphicRef<T extends React.ElementType> = React.ComponentPropsWithRef<T>['ref'];
+
+type TypographyProps<T extends React.ElementType> = TypographyOwnProps &
+  Omit<React.ComponentPropsWithoutRef<T>, keyof TypographyOwnProps>;
+
+type TypographyComponent = <T extends React.ElementType = 'p'>(
+  props: TypographyProps<T> & { ref?: PolymorphicRef<T> },
+) => React.ReactElement | null;
+
+const VARIANT_DEFAULT_ELEMENTS: Record<TypographyVariant, React.ElementType> = {
+  'heading-1': 'h1',
+  'heading-2': 'h2',
+  'heading-3': 'h3',
+  'body-1': 'p',
+  'body-1-medium': 'p',
+  'body-1-strong': 'p',
+  'body-2': 'p',
+  'body-2-strong': 'p',
+  'body-2-link': 'p',
+  'body-2-long': 'p',
+  'body-3': 'p',
+  'caption-1': 'span',
+  'caption-1-strong': 'span',
+};
+
+function resolveDefaultElement(variant: TypographyVariant): React.ElementType {
+  return VARIANT_DEFAULT_ELEMENTS[variant] ?? 'p';
+}
+
+function TypographyInner<T extends React.ElementType = 'p'>(
+  props: TypographyProps<T>,
+  ref: PolymorphicRef<T>,
+) {
+  const {
+    variant = DEFAULT_TYPOGRAPHY_VARIANT,
+    truncate = false,
+    noWrap = false,
+    as,
+    className,
+    children,
+    ...rest
+  } = props;
+
+  useEffect(() => {
+    ensureTypographyStyles();
+  }, []);
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (!TYPOGRAPHY_VARIANTS.includes(variant)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Typography: unsupported variant "${variant}". Falling back to token-driven defaults may not behave as expected.`,
+      );
+    }
+  }
+
+  const Component = (as ?? resolveDefaultElement(variant)) as React.ElementType;
+  const dataVariant = TYPOGRAPHY_VARIANTS.includes(variant)
+    ? variant
+    : DEFAULT_TYPOGRAPHY_VARIANT;
+
+  return (
+    <Component
+      {...(rest as React.ComponentPropsWithoutRef<T>)}
+      ref={ref}
+      className={[TYPOGRAPHY_CLASS_NAME, className].filter(Boolean).join(' ')}
+      data-variant={dataVariant}
+      data-truncate={truncate ? 'true' : undefined}
+      data-nowrap={noWrap ? 'true' : undefined}
+    >
+      {children}
+    </Component>
+  );
+}
+
+const Typography = forwardRef(TypographyInner as unknown as React.ForwardRefRenderFunction<
+  HTMLElement,
+  TypographyProps<React.ElementType>
+>) as unknown as TypographyComponent & { displayName?: string };
+
+Typography.displayName = 'Typography';
+
+export { Typography };
+export type { TypographyVariant };

--- a/src/components/Typography/__tests__/Typography.test.tsx
+++ b/src/components/Typography/__tests__/Typography.test.tsx
@@ -1,0 +1,77 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Typography } from '@components/Typography';
+import { DEFAULT_TYPOGRAPHY_VARIANT, ensureTypographyStyles } from '../typography.styles';
+
+describe('Typography', () => {
+  it('renders body text as a paragraph by default', () => {
+    render(<Typography>Readable copy</Typography>);
+
+    const paragraph = screen.getByText('Readable copy');
+
+    expect(paragraph.tagName).toBe('P');
+    expect(paragraph).toHaveAttribute('data-variant', DEFAULT_TYPOGRAPHY_VARIANT);
+    expect(paragraph).not.toHaveAttribute('data-truncate');
+  });
+
+  it('selects semantic elements for heading variants', () => {
+    render(
+      <>
+        <Typography variant="heading-1">Heading One</Typography>
+        <Typography variant="heading-2">Heading Two</Typography>
+        <Typography variant="heading-3">Heading Three</Typography>
+      </>,
+    );
+
+    expect(screen.getByRole('heading', { level: 1 })).toHaveAttribute('data-variant', 'heading-1');
+    expect(screen.getByRole('heading', { level: 2 })).toHaveAttribute('data-variant', 'heading-2');
+    expect(screen.getByRole('heading', { level: 3 })).toHaveAttribute('data-variant', 'heading-3');
+  });
+
+  it('accepts an `as` override without losing variant metadata', () => {
+    render(
+      <Typography variant="heading-2" as="p">
+        Custom element
+      </Typography>,
+    );
+
+    const element = screen.getByText('Custom element');
+
+    expect(element.tagName).toBe('P');
+    expect(element).toHaveAttribute('data-variant', 'heading-2');
+  });
+
+  it('supports truncate and noWrap attributes', () => {
+    render(
+      <Typography truncate noWrap>
+        Overflow content
+      </Typography>,
+    );
+
+    const element = screen.getByText('Overflow content');
+
+    expect(element).toHaveAttribute('data-truncate', 'true');
+    expect(element).toHaveAttribute('data-nowrap', 'true');
+  });
+
+  it('only injects styles into the document once', async () => {
+    render(
+      <>
+        <Typography>First</Typography>
+        <Typography>Second</Typography>
+      </>,
+    );
+
+    await waitFor(() => {
+      const styles = document.querySelectorAll('style[data-fivra-typography-styles="true"]');
+      expect(styles).toHaveLength(1);
+    });
+
+    ensureTypographyStyles();
+
+    const styles = document.querySelectorAll('style[data-fivra-typography-styles="true"]');
+    expect(styles).toHaveLength(1);
+  });
+});

--- a/src/components/Typography/index.ts
+++ b/src/components/Typography/index.ts
@@ -1,0 +1,9 @@
+export { Typography } from './Typography';
+export type { TypographyVariant } from './typography.styles';
+export {
+  DEFAULT_TYPOGRAPHY_VARIANT,
+  TYPOGRAPHY_CLASS_NAME,
+  TYPOGRAPHY_STYLES,
+  TYPOGRAPHY_VARIANTS,
+  ensureTypographyStyles,
+} from './typography.styles';

--- a/src/components/Typography/typography.styles.ts
+++ b/src/components/Typography/typography.styles.ts
@@ -1,0 +1,166 @@
+const TYPOGRAPHY_STYLE_ATTRIBUTE = 'data-fivra-typography-styles';
+
+export const TYPOGRAPHY_CLASS_NAME = 'fivra-typography';
+
+export const DEFAULT_TYPOGRAPHY_VARIANT = 'body-1';
+
+export type TypographyVariant =
+  | 'heading-1'
+  | 'heading-2'
+  | 'heading-3'
+  | 'body-1'
+  | 'body-1-medium'
+  | 'body-1-strong'
+  | 'body-2'
+  | 'body-2-strong'
+  | 'body-2-link'
+  | 'body-2-long'
+  | 'body-3'
+  | 'caption-1'
+  | 'caption-1-strong';
+
+type VariantTokenConfig = {
+  variant: TypographyVariant;
+  fontFamily: string;
+  fontWeight: string;
+  fontSize: string;
+  lineHeight: string;
+  letterSpacing?: string;
+};
+
+const VARIANT_TOKEN_CONFIGS: VariantTokenConfig[] = [
+  {
+    variant: 'heading-1',
+    fontFamily: '--heading1FontFamily',
+    fontWeight: '--heading1FontWeight',
+    fontSize: '--heading1FontSize',
+    lineHeight: '--heading1LineHeight',
+  },
+  {
+    variant: 'heading-2',
+    fontFamily: '--heading2FontFamily',
+    fontWeight: '--heading2FontWeight',
+    fontSize: '--heading2FontSize',
+    lineHeight: '--heading2LineHeight',
+  },
+  {
+    variant: 'heading-3',
+    fontFamily: '--heading3FontFamily',
+    fontWeight: '--heading3FontWeight',
+    fontSize: '--heading3FontSize',
+    lineHeight: '--heading3LineHeight',
+  },
+  {
+    variant: 'body-1',
+    fontFamily: '--body1FontFamily',
+    fontWeight: '--body1FontWeight',
+    fontSize: '--body1FontSize',
+    lineHeight: '--body1LineHeight',
+  },
+  {
+    variant: 'body-1-medium',
+    fontFamily: '--body1MediumFontFamily',
+    fontWeight: '--body1MediumFontWeight',
+    fontSize: '--body1MediumFontSize',
+    lineHeight: '--body1MediumLineHeight',
+  },
+  {
+    variant: 'body-1-strong',
+    fontFamily: '--body1StrongFontFamily',
+    fontWeight: '--body1StrongFontWeight',
+    fontSize: '--body1StrongFontSize',
+    lineHeight: '--body1StrongLineHeight',
+  },
+  {
+    variant: 'body-2',
+    fontFamily: '--body2FontFamily',
+    fontWeight: '--body2FontWeight',
+    fontSize: '--body2FontSize',
+    lineHeight: '--body2LineHeight',
+    letterSpacing: '--body2LetterSpacing',
+  },
+  {
+    variant: 'body-2-strong',
+    fontFamily: '--body2StrongFontFamily',
+    fontWeight: '--body2StrongFontWeight',
+    fontSize: '--body2StrongFontSize',
+    lineHeight: '--body2StrongLineHeight',
+    letterSpacing: '--body2StrongLetterSpacing',
+  },
+  {
+    variant: 'body-2-link',
+    fontFamily: '--body2LinkFontFamily',
+    fontWeight: '--body2LinkFontWeight',
+    fontSize: '--body2LinkFontSize',
+    lineHeight: '--body2LinkLineHeight',
+    letterSpacing: '--body2LinkLetterSpacing',
+  },
+  {
+    variant: 'body-2-long',
+    fontFamily: '--body2LongFontFamily',
+    fontWeight: '--body2LongFontWeight',
+    fontSize: '--body2LongFontSize',
+    lineHeight: '--body2LongLineHeight',
+    letterSpacing: '--body2LongLetterSpacing',
+  },
+  {
+    variant: 'body-3',
+    fontFamily: '--body3FontFamily',
+    fontWeight: '--body3FontWeight',
+    fontSize: '--body3FontSize',
+    lineHeight: '--body3LineHeight',
+    letterSpacing: '--body3LetterSpacing',
+  },
+  {
+    variant: 'caption-1',
+    fontFamily: '--caption1FontFamily',
+    fontWeight: '--caption1FontWeight',
+    fontSize: '--caption1FontSize',
+    lineHeight: '--caption1LineHeight',
+    letterSpacing: '--caption1LetterSpacing',
+  },
+  {
+    variant: 'caption-1-strong',
+    fontFamily: '--caption1StrongFontFamily',
+    fontWeight: '--caption1StrongFontWeight',
+    fontSize: '--caption1StrongFontSize',
+    lineHeight: '--caption1StrongLineHeight',
+    letterSpacing: '--caption1StrongLetterSpacing',
+  },
+];
+
+const typographyVariantStyles = VARIANT_TOKEN_CONFIGS.map((config) => {
+  const letterSpacingDeclaration = config.letterSpacing
+    ? `  letter-spacing: var(${config.letterSpacing});\n`
+    : '';
+
+  return `.${TYPOGRAPHY_CLASS_NAME}[data-variant="${config.variant}"] {\n  font-family: var(${config.fontFamily});\n  font-weight: var(${config.fontWeight});\n  font-size: var(${config.fontSize});\n  line-height: var(${config.lineHeight});\n${letterSpacingDeclaration}}`;
+}).join('\n\n');
+
+const TYPOGRAPHY_BASE_STYLES = `.${TYPOGRAPHY_CLASS_NAME} {\n  margin: 0;\n  color: var(--textNeutral1);\n}\n\n.${TYPOGRAPHY_CLASS_NAME}[data-truncate="true"] {\n  max-width: 100%;\n  overflow: hidden;\n  text-overflow: ellipsis;\n  white-space: nowrap;\n}\n\n.${TYPOGRAPHY_CLASS_NAME}[data-nowrap="true"] {\n  white-space: nowrap;\n}\n\n.${TYPOGRAPHY_CLASS_NAME}[data-variant="body-2-link"] {\n  color: var(--textPrimaryInteractive, var(--textNeutral1));\n  text-decoration: underline;\n}\n`;
+
+const TYPOGRAPHY_STYLES = `${TYPOGRAPHY_BASE_STYLES}\n${typographyVariantStyles}`;
+
+export const TYPOGRAPHY_VARIANTS = VARIANT_TOKEN_CONFIGS.map((config) => config.variant) as readonly TypographyVariant[];
+
+let hasInjectedTypographyStyles = false;
+
+export function ensureTypographyStyles(): void {
+  if (hasInjectedTypographyStyles || typeof document === 'undefined') {
+    return;
+  }
+
+  const existing = document.querySelector(`style[${TYPOGRAPHY_STYLE_ATTRIBUTE}="true"]`);
+  if (existing) {
+    hasInjectedTypographyStyles = true;
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.setAttribute(TYPOGRAPHY_STYLE_ATTRIBUTE, 'true');
+  style.textContent = TYPOGRAPHY_STYLES;
+  document.head.appendChild(style);
+  hasInjectedTypographyStyles = true;
+}
+
+export { TYPOGRAPHY_STYLES };

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,2 +1,3 @@
 export * from './Button';
 export * from './Icon';
+export * from './Typography';


### PR DESCRIPTION
## Summary
- add a token-backed Typography style injector and React wrapper that maps Engage variants
- document the component contract with tests, Storybook stories, and reference docs
- update exports, governance logs, and changeset metadata for the new primitive

## Testing
- yarn build
- yarn test
- yarn verify:agents

------
https://chatgpt.com/codex/tasks/task_e_68e291d96f80832c96aaa40e51e6ab12