### PR TITLE
feat: add Box layout primitive

### DIFF
--- a/.changeset/box-layout-primitive.md
+++ b/.changeset/box-layout-primitive.md
@@ -1,0 +1,5 @@
+---
+"design-system-icons": minor
+---
+
+Introduce the token-aware Box layout primitive with spacing shorthands, shared style injector, stories, tests, and documentation.

--- a/docs/components/AGENTS.md
+++ b/docs/components/AGENTS.md
@@ -14,3 +14,4 @@ This directory inherits the repository and `docs/` guidance. Keep component refe
 - 1.8.1: Cross-linked the Button docs to the component contract so updates stay synchronized across references.
 - 1.8.2: Noted canonical Storybook and visual test references in the Button contract for doc maintainers.
 - 1.9.0: Documented the Typography primitive, covering variant mapping, accessibility, and token references.
+- 1.10.0: Added Box documentation outlining spacing tokens, layout helpers, and the shared contract link.

--- a/docs/components/box.md
+++ b/docs/components/box.md
@@ -1,0 +1,102 @@
+# Box
+
+Box provides a token-aware layout primitive for spacing, background, and alignment utilities. It forwards refs, respects polymorphic `as` overrides, and injects a single reset stylesheet so every framework adapter shares the same baseline (`box-sizing: border-box`, `min-width: 0`, `min-height: 0`).
+
+Review the [Box component contract](../../src/components/Box/AGENTS.md#component-contract) for the authoritative prop list and governance details. Keep this reference aligned with Storybook examples and implementation updates.
+
+- Source: [`src/components/Box/Box.tsx`](../../src/components/Box/Box.tsx)
+- Styles: [`src/components/Box/box.styles.ts`](../../src/components/Box/box.styles.ts)
+- Stories: [`src/components/Box/Box.stories.tsx`](../../src/components/Box/Box.stories.tsx)
+
+## React usage
+
+```tsx
+import { Box } from '@fivra/design-system';
+
+export function SummaryCard() {
+  return (
+    <Box
+      as="section"
+      aria-labelledby="summary-heading"
+      backgroundColor="background-neutral-0"
+      borderRadius="radius-l"
+      p="spacing-l"
+      display="grid"
+      gap="spacing-m"
+    >
+      <Box as="h2" id="summary-heading" style={{ margin: 0 }}>
+        Account summary
+      </Box>
+      <Box color="text-neutral-2">
+        Use spacing tokens (e.g., `spacing-m`) to create consistent gutters without hardcoding pixel values.
+      </Box>
+      <Box display="flex" gap="spacing-s" justifyContent="flex-end">
+        <Box
+          as="button"
+          type="button"
+          backgroundColor="background-primary-interactive"
+          color="background-neutral-0"
+          px="spacing-m"
+          py="spacing-s"
+          borderRadius="radius-s"
+          style={{ border: 'none', cursor: 'pointer' }}
+        >
+          Update
+        </Box>
+        <Box
+          as="button"
+          type="button"
+          backgroundColor="background-neutral-0"
+          color="text-neutral-2"
+          px="spacing-m"
+          py="spacing-s"
+          borderRadius="radius-s"
+          borderWidth="border-width-s"
+          style={{ borderStyle: 'solid', cursor: 'pointer' }}
+        >
+          Dismiss
+        </Box>
+      </Box>
+    </Box>
+  );
+}
+```
+
+### Props
+
+| Prop | Type | Description |
+| --- | --- | --- |
+| `as` | `React.ElementType` | Overrides the rendered element. Defaults to `<div>` when unspecified. |
+| `display` | `React.CSSProperties['display']` | Sets layout mode (`flex`, `grid`, etc.). |
+| `flexDirection`, `justifyContent`, `alignItems`, `flexWrap` | `React.CSSProperties[...]` | Direct pass-through to the matching CSS flexbox properties. |
+| `gap`, `rowGap`, `columnGap` | `BoxSpacingToken \| number \| string` | Applies spacing tokens such as `spacing-m`, numeric pixel values, or raw CSS lengths. |
+| `p`, `px`, `py`, `pt`, `pr`, `pb`, `pl` | `BoxSpacingToken \| number \| string` | Padding shorthands. Axis (`px`, `py`) and side props override broader settings. |
+| `m`, `mx`, `my`, `mt`, `mr`, `mb`, `ml` | `BoxSpacingToken \| number \| string` | Margin shorthands with the same precedence rules as padding. |
+| `backgroundColor`, `color`, `borderColor` | `string` | Accept Engage token strings like `background-neutral-0` or raw CSS values. Tokens become `var(--tokenName)` references. |
+| `borderRadius` | `BoxRadiusToken \| number \| string` | Maps radius tokens (`radius-m`) to `var(--radiusM)` or accepts custom values. |
+| `borderWidth` | `BoxBorderWidthToken \| number \| string` | Converts border width tokens (`border-width-s`) to `calc(var(--borderwidthS) * 1px)` or forwards raw CSS. |
+| `boxShadow` | `string` | Optional shadow token (e.g., `shadow-m`) or raw CSS shadow declaration. |
+| `width`, `height` | `BoxSpacingToken \| number \| string` | Accept spacing tokens, numbers (pixels), or raw CSS for dimensions. |
+| `style` | `React.CSSProperties` | Inline overrides merged after token resolution so author styles win. |
+| `...boxProps` | `React.ComponentPropsWithoutRef<T>` | Native attributes for the chosen element (`id`, `role`, event handlers, etc.). |
+
+## Accessibility
+
+- Box does not assign implicit roles; choose the correct `as` element (e.g., `<section>`, `<nav>`, `<button>`) for semantics.
+- Ensure interactive children meet focus and labeling requirements when using Box as a structural wrapper.
+- Base resets include `box-sizing: border-box`, preventing overflow issues when padding is applied across nested layouts.
+
+## Theming
+
+Box relies on Engage CSS custom properties for background, text, radius, border width, and spacing scales. Override tokens at the theme or container scope to restyle composed layouts without changing component code.
+
+```css
+.dashboard-shell {
+  --backgroundNeutral0: #1d1a2b;
+  --textNeutral1: #f7f7f8;
+  --spacingL: 20;
+  --radiusL: 18;
+}
+```
+
+Wrap your feature area with `.dashboard-shell` (or switch `data-fivra-theme`) so the updated token values cascade into every Box instance.

--- a/src/components/AGENTS.md
+++ b/src/components/AGENTS.md
@@ -28,3 +28,4 @@ This document extends the root-level `AGENTS.md`. All contributors must read and
 - 1.8.4: Updated the Icon component to merge CSS token sizes into inline styles, added tests, and expanded stories to demonstrate token-driven sizing overrides.
 - 1.9.3: Retitled the Icon stories to `Atomics/Icon` and assigned a React meta ID for Storybook composition alignment.
 - 1.10.0: Introduced the token-backed React Typography primitive with shared style injector and cross-framework contract.
+- 1.11.0: Added the Box layout primitive with spacing shorthands, shared style injector, tests, stories, and documentation references.

--- a/src/components/Box/AGENTS.md
+++ b/src/components/Box/AGENTS.md
@@ -1,0 +1,15 @@
+# Box Component Guidelines
+
+This directory inherits the repository root `AGENTS.md` and `src/components/AGENTS.md`. Review those policies before modifying files within `src/components/Box/`.
+
+## Component Contract
+- `Box` is a polymorphic layout primitive that defaults to a `<div>` and forwards refs.
+- Spacing props (`m`, `mx`, `my`, `mt`, `mr`, `mb`, `ml`, `p`, `px`, `py`, `pt`, `pr`, `pb`, `pl`, `gap`, `rowGap`, `columnGap`) accept raw CSS values, numbers (treated as pixels), or Engage spacing tokens formatted as `spacing-{scale}` (`spacing-xs-3` → `calc(var(--spacingXs3) * 1px)`). Axis and side shorthands override broader settings.
+- Visual tokens accept Engage hyphenated names and resolve to CSS custom properties: e.g., `background-neutral-0` → `var(--backgroundNeutral0)`, `radius-m` → `var(--radiusM)`, `border-width-s` → `calc(var(--borderwidthS) * 1px)`. Raw CSS strings remain untouched.
+- Layout helpers map directly to CSS properties: `display`, `flexDirection`, `justifyContent`, `alignItems`, `flexWrap`, `width`, and `height`.
+- Accessibility defaults preserve author intent by avoiding implicit roles; the primitive simply renders the requested element and passes through semantics.
+- `ensureBoxStyles()` injects a single reset stylesheet (`box-sizing: border-box`, `min-width: 0`, `min-height: 0`) shared across frameworks. Call it before rendering in new adapters.
+
+## Functional Changes
+- Use `<major>.<minor>[.<patch>]` labels instead of dates when recording new entries.
+- 1.0.0: Introduced the token-driven Box primitive with spacing shorthands, style injector, tests, stories, and documentation.

--- a/src/components/Box/Box.stories.tsx
+++ b/src/components/Box/Box.stories.tsx
@@ -1,0 +1,161 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import { Box } from '@components/Box';
+
+const meta: Meta<typeof Box> = {
+  title: 'Atomics/Box',
+  id: 'atomics-box-react',
+  component: Box,
+  tags: ['autodocs'],
+  argTypes: {
+    as: { control: false },
+    display: {
+      control: 'text',
+      description: 'Sets the CSS display property for the rendered element.',
+    },
+    p: {
+      control: 'text',
+      description: 'Padding shorthand accepting Engage spacing tokens (e.g., `spacing-m`).',
+      table: { category: 'Spacing' },
+    },
+    m: {
+      control: 'text',
+      description: 'Margin shorthand accepting Engage spacing tokens (e.g., `spacing-s`).',
+      table: { category: 'Spacing' },
+    },
+    backgroundColor: {
+      control: 'text',
+      description: 'Background fill accepting Engage tokens like `background-neutral-0`.',
+      table: { category: 'Appearance' },
+    },
+    borderRadius: {
+      control: 'text',
+      description: 'Corner radius token (e.g., `radius-m`).',
+      table: { category: 'Appearance' },
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Low-level layout primitive exposing spacing shorthands, layout helpers, and token-backed color utilities. Useful for composing stories and surface shells without bespoke wrappers.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Box>;
+
+export const PaddingAndMarginTokens: Story = {
+  name: 'Padding & margin tokens',
+  render: () => (
+    <Box backgroundColor="background-neutral-6" p="spacing-xl" gap="spacing-m" display="grid">
+      <Box backgroundColor="background-neutral-0" p="spacing-m" borderRadius="radius-m">
+        Base padding applied via <code>p</code> with Engage spacing tokens.
+      </Box>
+      <Box
+        backgroundColor="background-neutral-0"
+        p="spacing-m"
+        borderRadius="radius-m"
+        mb="spacing-s"
+      >
+        Bottom margin tokens like <code>mb</code> space stacked content consistently.
+      </Box>
+      <Box backgroundColor="background-neutral-0" px="spacing-l" py="spacing-s" borderRadius="radius-m">
+        Axis shorthands (`px`, `py`) cascade until side-specific overrides are provided.
+      </Box>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Spacing props map to Engage tokens such as `spacing-xl` or `spacing-s`, converting them to pixel values via CSS custom properties.',
+      },
+    },
+  },
+};
+
+export const FlexAlignment: Story = {
+  render: () => (
+    <Box display="flex" gap="spacing-l" alignItems="center" justifyContent="space-between" p="spacing-m" backgroundColor="background-neutral-0" borderRadius="radius-l">
+      <Box backgroundColor="background-neutral-6" p="spacing-s" borderRadius="radius-s">
+        Start
+      </Box>
+      <Box display="flex" gap="spacing-s" alignItems="center">
+        <Box backgroundColor="background-primary-interactive" color="background-neutral-0" p="spacing-xs" borderRadius="radius-xs">
+          Flex child
+        </Box>
+        <Box backgroundColor="background-secondary-interactive" color="text-neutral-1" p="spacing-xs" borderRadius="radius-xs">
+          Aligns center
+        </Box>
+      </Box>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Flexbox helpers (`display`, `justifyContent`, `alignItems`, `gap`) provide quick wrappers for Storybook controls and layout scaffolding.',
+      },
+    },
+  },
+};
+
+export const BackgroundUtilities: Story = {
+  render: () => (
+    <Box display="grid" gap="spacing-m" p="spacing-m" backgroundColor="background-neutral-6" borderRadius="radius-l">
+      <Box backgroundColor="background-primary-interactive" color="background-neutral-0" p="spacing-m" borderRadius="radius-m">
+        Primary background
+      </Box>
+      <Box backgroundColor="background-secondary-interactive" color="text-neutral-1" p="spacing-m" borderRadius="radius-m">
+        Secondary background
+      </Box>
+      <Box backgroundColor="background-tertiary-interactive" color="background-neutral-0" p="spacing-m" borderRadius="radius-m">
+        Tertiary background
+      </Box>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Background and text props accept Engage token strings, resolving them to `var(--tokenName)` references for consistent theme usage.',
+      },
+    },
+  },
+};
+
+export const NestedComposition: Story = {
+  render: () => (
+    <Box display="grid" gap="spacing-l" p="spacing-l" backgroundColor="background-neutral-6" borderRadius="radius-l">
+      <Box display="grid" gap="spacing-s" backgroundColor="background-neutral-0" borderRadius="radius-m" p="spacing-m">
+        <Box as="h3" style={{ margin: 0, fontWeight: 600 }}>
+          Card title
+        </Box>
+        <Box color="text-neutral-2">
+          Reusable layout primitive enables nested shells without bespoke wrappers, ensuring consistent spacing and token usage.
+        </Box>
+        <Box display="flex" gap="spacing-s" justifyContent="flex-end">
+          <Box as="button" type="button" backgroundColor="background-primary-interactive" color="background-neutral-0" px="spacing-m" py="spacing-s" borderRadius="radius-s" style={{ border: 'none', cursor: 'pointer' }}>
+            Action
+          </Box>
+          <Box as="button" type="button" backgroundColor="background-neutral-0" color="text-neutral-2" px="spacing-m" py="spacing-s" borderRadius="radius-s" style={{ border: '1px solid var(--borderNeutral4)', cursor: 'pointer' }}>
+            Cancel
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Nested composition highlights how `Box` can wrap interactive elements, grids, and flex rows while preserving author-supplied styles.',
+      },
+    },
+  },
+};

--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,0 +1,513 @@
+import React, { forwardRef, useEffect } from 'react';
+
+import {
+  BOX_BORDER_WIDTH_TOKENS,
+  BOX_CLASS_NAME,
+  BOX_RADIUS_TOKENS,
+  BOX_SPACING_TOKENS,
+  type BoxBorderWidthToken,
+  type BoxRadiusToken,
+  type BoxSpacingToken,
+  ensureBoxStyles,
+} from './box.styles';
+
+type BoxSpacingValue = BoxSpacingToken | number | string;
+
+type BoxOwnProps<T extends React.ElementType> = {
+  as?: T;
+  className?: string;
+  children?: React.ReactNode;
+  style?: React.CSSProperties;
+  // Margin helpers
+  m?: BoxSpacingValue;
+  mx?: BoxSpacingValue;
+  my?: BoxSpacingValue;
+  mt?: BoxSpacingValue;
+  mr?: BoxSpacingValue;
+  mb?: BoxSpacingValue;
+  ml?: BoxSpacingValue;
+  // Padding helpers
+  p?: BoxSpacingValue;
+  px?: BoxSpacingValue;
+  py?: BoxSpacingValue;
+  pt?: BoxSpacingValue;
+  pr?: BoxSpacingValue;
+  pb?: BoxSpacingValue;
+  pl?: BoxSpacingValue;
+  // Gap helpers
+  gap?: BoxSpacingValue;
+  rowGap?: BoxSpacingValue;
+  columnGap?: BoxSpacingValue;
+  // Layout
+  display?: React.CSSProperties['display'];
+  flexDirection?: React.CSSProperties['flexDirection'];
+  justifyContent?: React.CSSProperties['justifyContent'];
+  alignItems?: React.CSSProperties['alignItems'];
+  flexWrap?: React.CSSProperties['flexWrap'];
+  // Visual props
+  backgroundColor?: string;
+  color?: string;
+  borderColor?: string;
+  borderRadius?: BoxRadiusToken | number | string;
+  borderWidth?: BoxBorderWidthToken | number | string;
+  boxShadow?: React.CSSProperties['boxShadow'];
+  width?: BoxSpacingValue;
+  height?: BoxSpacingValue;
+};
+
+type PolymorphicRef<T extends React.ElementType> = React.ComponentPropsWithRef<T>['ref'];
+
+type BoxProps<T extends React.ElementType> = BoxOwnProps<T> &
+  Omit<React.ComponentPropsWithoutRef<T>, keyof BoxOwnProps<T>>;
+
+type BoxComponent = <T extends React.ElementType = 'div'>(
+  props: BoxProps<T> & { ref?: PolymorphicRef<T> },
+) => React.ReactElement | null;
+
+const spacingTokenSet = new Set<string>(BOX_SPACING_TOKENS);
+const radiusTokenSet = new Set<string>(BOX_RADIUS_TOKENS);
+const borderWidthTokenSet = new Set<string>(BOX_BORDER_WIDTH_TOKENS);
+
+function isSpacingToken(value: string): value is BoxSpacingToken {
+  return spacingTokenSet.has(value);
+}
+
+function isRadiusToken(value: string): value is BoxRadiusToken {
+  return radiusTokenSet.has(value);
+}
+
+function isBorderWidthToken(value: string): value is BoxBorderWidthToken {
+  return borderWidthTokenSet.has(value);
+}
+
+function capitalizeTokenSegment(segment: string): string {
+  if (!segment) {
+    return segment;
+  }
+
+  return segment[0].toUpperCase() + segment.slice(1);
+}
+
+function toCssVariableName(token: string): string {
+  const [first, ...rest] = token.split('-');
+  const suffix = rest.map(capitalizeTokenSegment).join('');
+  return `--${first}${suffix}`;
+}
+
+function resolveSpacingValue(value: BoxSpacingValue | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+
+  if (typeof value === 'string') {
+    if (isSpacingToken(value)) {
+      return `calc(var(${toCssVariableName(value)}) * 1px)`;
+    }
+
+    if (isDesignToken(value) && value.startsWith('spacing-')) {
+      return `calc(var(${toCssVariableName(value)}) * 1px)`;
+    }
+
+    return value;
+  }
+
+  return value;
+}
+
+function isDesignToken(value: string): boolean {
+  return /^[a-z]+(?:-[a-z0-9]+)+$/i.test(value);
+}
+
+function resolveColorValue(value: string | undefined): string | undefined {
+  if (!value) {
+    return value;
+  }
+
+  if (value.startsWith('var(') || value.startsWith('calc(')) {
+    return value;
+  }
+
+  if (isDesignToken(value)) {
+    return `var(${toCssVariableName(value)})`;
+  }
+
+  return value;
+}
+
+function resolveRadiusValue(value: BoxOwnProps<React.ElementType>['borderRadius']): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+
+  if (typeof value === 'string') {
+    if (isRadiusToken(value)) {
+      return `var(${toCssVariableName(value)})`;
+    }
+
+    if (isDesignToken(value) && value.startsWith('radius-')) {
+      return `var(${toCssVariableName(value)})`;
+    }
+
+    return value;
+  }
+
+  return value;
+}
+
+function resolveBorderWidthValue(
+  value: BoxOwnProps<React.ElementType>['borderWidth'],
+): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+
+  if (typeof value === 'string') {
+    if (isBorderWidthToken(value)) {
+      return `calc(var(${toCssVariableName(value)}) * 1px)`;
+    }
+
+    if (isDesignToken(value) && value.startsWith('border-width-')) {
+      return `calc(var(${toCssVariableName(value)}) * 1px)`;
+    }
+
+    return value;
+  }
+
+  return value;
+}
+
+function resolveDimensionValue(value: BoxSpacingValue | undefined): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (typeof value === 'number') {
+    return `${value}px`;
+  }
+
+  if (typeof value === 'string') {
+    if (isSpacingToken(value) || (isDesignToken(value) && value.startsWith('spacing-'))) {
+      return `calc(var(${toCssVariableName(value)}) * 1px)`;
+    }
+
+    return value;
+  }
+
+  return value;
+}
+
+function resolveBoxShadowValue(value: React.CSSProperties['boxShadow']): React.CSSProperties['boxShadow'] {
+  if (!value || typeof value !== 'string') {
+    return value;
+  }
+
+  if (value.startsWith('var(')) {
+    return value;
+  }
+
+  if (isDesignToken(value) && value.startsWith('shadow-')) {
+    return `var(${toCssVariableName(value)})`;
+  }
+
+  return value;
+}
+
+type MutableStyle = React.CSSProperties & Record<string, unknown>;
+
+type SpacingProps = Pick<
+  BoxOwnProps<React.ElementType>,
+  | 'm'
+  | 'mx'
+  | 'my'
+  | 'mt'
+  | 'mr'
+  | 'mb'
+  | 'ml'
+  | 'p'
+  | 'px'
+  | 'py'
+  | 'pt'
+  | 'pr'
+  | 'pb'
+  | 'pl'
+  | 'gap'
+  | 'rowGap'
+  | 'columnGap'
+>;
+
+function applySpacing(style: MutableStyle, props: SpacingProps): void {
+  const marginOrder: Array<keyof SpacingProps> = ['m', 'mx', 'my', 'mt', 'mr', 'mb', 'ml'];
+  const paddingOrder: Array<keyof SpacingProps> = ['p', 'px', 'py', 'pt', 'pr', 'pb', 'pl'];
+
+  for (const key of marginOrder) {
+    const value = props[key];
+    if (value === undefined) {
+      continue;
+    }
+
+    const resolved = resolveSpacingValue(value);
+    if (resolved === undefined) {
+      continue;
+    }
+
+    switch (key) {
+      case 'm':
+        style.marginTop = resolved;
+        style.marginRight = resolved;
+        style.marginBottom = resolved;
+        style.marginLeft = resolved;
+        break;
+      case 'mx':
+        style.marginLeft = resolved;
+        style.marginRight = resolved;
+        break;
+      case 'my':
+        style.marginTop = resolved;
+        style.marginBottom = resolved;
+        break;
+      case 'mt':
+        style.marginTop = resolved;
+        break;
+      case 'mr':
+        style.marginRight = resolved;
+        break;
+      case 'mb':
+        style.marginBottom = resolved;
+        break;
+      case 'ml':
+        style.marginLeft = resolved;
+        break;
+      default:
+        break;
+    }
+  }
+
+  for (const key of paddingOrder) {
+    const value = props[key];
+    if (value === undefined) {
+      continue;
+    }
+
+    const resolved = resolveSpacingValue(value);
+    if (resolved === undefined) {
+      continue;
+    }
+
+    switch (key) {
+      case 'p':
+        style.paddingTop = resolved;
+        style.paddingRight = resolved;
+        style.paddingBottom = resolved;
+        style.paddingLeft = resolved;
+        break;
+      case 'px':
+        style.paddingLeft = resolved;
+        style.paddingRight = resolved;
+        break;
+      case 'py':
+        style.paddingTop = resolved;
+        style.paddingBottom = resolved;
+        break;
+      case 'pt':
+        style.paddingTop = resolved;
+        break;
+      case 'pr':
+        style.paddingRight = resolved;
+        break;
+      case 'pb':
+        style.paddingBottom = resolved;
+        break;
+      case 'pl':
+        style.paddingLeft = resolved;
+        break;
+      default:
+        break;
+    }
+  }
+
+  if (props.gap !== undefined) {
+    const resolved = resolveSpacingValue(props.gap);
+    if (resolved !== undefined) {
+      style.gap = resolved;
+    }
+  }
+
+  if (props.rowGap !== undefined) {
+    const resolved = resolveSpacingValue(props.rowGap);
+    if (resolved !== undefined) {
+      style.rowGap = resolved;
+    }
+  }
+
+  if (props.columnGap !== undefined) {
+    const resolved = resolveSpacingValue(props.columnGap);
+    if (resolved !== undefined) {
+      style.columnGap = resolved;
+    }
+  }
+}
+
+function BoxInner<T extends React.ElementType = 'div'>(
+  props: BoxProps<T>,
+  ref: PolymorphicRef<T>,
+) {
+  const {
+    as,
+    className,
+    children,
+    style,
+    m,
+    mx,
+    my,
+    mt,
+    mr,
+    mb,
+    ml,
+    p,
+    px,
+    py,
+    pt,
+    pr,
+    pb,
+    pl,
+    gap,
+    rowGap,
+    columnGap,
+    display,
+    flexDirection,
+    justifyContent,
+    alignItems,
+    flexWrap,
+    backgroundColor,
+    color,
+    borderColor,
+    borderRadius,
+    borderWidth,
+    boxShadow,
+    width,
+    height,
+    ...rest
+  } = props;
+
+  useEffect(() => {
+    ensureBoxStyles();
+  }, []);
+
+  const Component = (as ?? 'div') as React.ElementType;
+
+  const computedStyle: MutableStyle = {};
+  applySpacing(computedStyle, {
+    m,
+    mx,
+    my,
+    mt,
+    mr,
+    mb,
+    ml,
+    p,
+    px,
+    py,
+    pt,
+    pr,
+    pb,
+    pl,
+    gap,
+    rowGap,
+    columnGap,
+  });
+
+  if (display !== undefined) {
+    computedStyle.display = display;
+  }
+
+  if (flexDirection !== undefined) {
+    computedStyle.flexDirection = flexDirection;
+  }
+
+  if (justifyContent !== undefined) {
+    computedStyle.justifyContent = justifyContent;
+  }
+
+  if (alignItems !== undefined) {
+    computedStyle.alignItems = alignItems;
+  }
+
+  if (flexWrap !== undefined) {
+    computedStyle.flexWrap = flexWrap;
+  }
+
+  const resolvedBackground = resolveColorValue(backgroundColor);
+  if (resolvedBackground !== undefined) {
+    computedStyle.backgroundColor = resolvedBackground;
+  }
+
+  const resolvedColor = resolveColorValue(color);
+  if (resolvedColor !== undefined) {
+    computedStyle.color = resolvedColor;
+  }
+
+  const resolvedBorderColor = resolveColorValue(borderColor);
+  if (resolvedBorderColor !== undefined) {
+    computedStyle.borderColor = resolvedBorderColor;
+  }
+
+  const resolvedBorderRadius = resolveRadiusValue(borderRadius);
+  if (resolvedBorderRadius !== undefined) {
+    computedStyle.borderRadius = resolvedBorderRadius;
+  }
+
+  const resolvedBorderWidth = resolveBorderWidthValue(borderWidth);
+  if (resolvedBorderWidth !== undefined) {
+    computedStyle.borderWidth = resolvedBorderWidth;
+  }
+
+  const resolvedBoxShadow = resolveBoxShadowValue(boxShadow);
+  if (resolvedBoxShadow !== undefined) {
+    computedStyle.boxShadow = resolvedBoxShadow;
+  }
+
+  const resolvedWidth = resolveDimensionValue(width);
+  if (resolvedWidth !== undefined) {
+    computedStyle.width = resolvedWidth;
+  }
+
+  const resolvedHeight = resolveDimensionValue(height);
+  if (resolvedHeight !== undefined) {
+    computedStyle.height = resolvedHeight;
+  }
+
+  const mergedStyle = style ? { ...computedStyle, ...style } : computedStyle;
+
+  return (
+    <Component
+      {...(rest as React.ComponentPropsWithoutRef<T>)}
+      ref={ref}
+      className={[BOX_CLASS_NAME, className].filter(Boolean).join(' ')}
+      style={mergedStyle}
+    >
+      {children}
+    </Component>
+  );
+}
+
+const Box = forwardRef(BoxInner as unknown as React.ForwardRefRenderFunction<
+  HTMLElement,
+  BoxProps<React.ElementType>
+>) as unknown as BoxComponent & { displayName?: string };
+
+Box.displayName = 'Box';
+
+export { Box };
+export type { BoxBorderWidthToken, BoxProps, BoxRadiusToken, BoxSpacingToken };

--- a/src/components/Box/__tests__/Box.test.tsx
+++ b/src/components/Box/__tests__/Box.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { Box } from '@components/Box';
+import { BOX_CLASS_NAME, BOX_STYLE_ATTRIBUTE, ensureBoxStyles } from '../box.styles';
+
+describe('Box', () => {
+  it('renders a div by default and forwards children', () => {
+    render(
+      <Box data-testid="layout-box">
+        <span>Content</span>
+      </Box>,
+    );
+
+    const element = screen.getByTestId('layout-box');
+    expect(element.tagName).toBe('DIV');
+    expect(element.classList.contains(BOX_CLASS_NAME)).toBe(true);
+    expect(element).toHaveTextContent('Content');
+  });
+
+  it('respects polymorphic `as` overrides', () => {
+    render(
+      <Box as="section" data-testid="section-box">
+        Section content
+      </Box>,
+    );
+
+    const element = screen.getByTestId('section-box');
+    expect(element.tagName).toBe('SECTION');
+  });
+
+  it('applies spacing shorthands with side precedence', () => {
+    render(
+      <Box
+        data-testid="spacing-box"
+        p="spacing-m"
+        px="spacing-s"
+        pl="spacing-l"
+      />,
+    );
+
+    const element = screen.getByTestId('spacing-box');
+    const { cssText } = element.style;
+    expect(cssText).toContain('padding-top: calc(var(--spacingM) * 1px)');
+    expect(cssText).toContain('padding-bottom: calc(var(--spacingM) * 1px)');
+    expect(cssText).toContain('padding-right: calc(var(--spacingS) * 1px)');
+    expect(cssText).toContain('padding-left: calc(var(--spacingL) * 1px)');
+  });
+
+  it('converts token props to CSS custom property references', () => {
+    render(
+      <Box
+        data-testid="token-box"
+        backgroundColor="background-neutral-0"
+        borderRadius="radius-m"
+      />,
+    );
+
+    const element = screen.getByTestId('token-box');
+    expect(element.style.backgroundColor).toBe('var(--backgroundNeutral0)');
+    expect(element.style.borderRadius).toBe('var(--radiusM)');
+  });
+
+  it('wires display and flexbox helpers', () => {
+    render(
+      <Box
+        data-testid="flex-box"
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        alignItems="flex-start"
+        gap="spacing-m"
+      />,
+    );
+
+    const element = screen.getByTestId('flex-box');
+    expect(element.style.display).toBe('flex');
+    expect(element.style.flexDirection).toBe('column');
+    expect(element.style.justifyContent).toBe('center');
+    expect(element.style.alignItems).toBe('flex-start');
+    expect(element.style.gap).toBe('calc(var(--spacingM) * 1px)');
+  });
+
+  it('only injects styles into the document once', async () => {
+    render(
+      <>
+        <Box data-testid="first-box" />
+        <Box data-testid="second-box" />
+      </>,
+    );
+
+    await waitFor(() => {
+      const styles = document.querySelectorAll(`style[${BOX_STYLE_ATTRIBUTE}="true"]`);
+      expect(styles).toHaveLength(1);
+    });
+
+    ensureBoxStyles();
+
+    const styles = document.querySelectorAll(`style[${BOX_STYLE_ATTRIBUTE}="true"]`);
+    expect(styles).toHaveLength(1);
+  });
+});

--- a/src/components/Box/box.styles.ts
+++ b/src/components/Box/box.styles.ts
@@ -1,0 +1,66 @@
+const BOX_STYLE_ATTRIBUTE = 'data-fivra-box-styles';
+
+export const BOX_CLASS_NAME = 'fivra-box';
+
+export const BOX_SPACING_TOKENS = [
+  'spacing-xs-3',
+  'spacing-xs-2',
+  'spacing-xs',
+  'spacing-s',
+  'spacing-m',
+  'spacing-l',
+  'spacing-xl',
+  'spacing-xl-2',
+  'spacing-xl-3',
+  'spacing-xl-4',
+] as const;
+
+export type BoxSpacingToken = (typeof BOX_SPACING_TOKENS)[number];
+
+export const BOX_RADIUS_TOKENS = [
+  'radius-none',
+  'radius-xs-2',
+  'radius-xs',
+  'radius-s',
+  'radius-m',
+  'radius-l',
+  'radius-xl',
+  'radius-max',
+] as const;
+
+export type BoxRadiusToken = (typeof BOX_RADIUS_TOKENS)[number];
+
+export const BOX_BORDER_WIDTH_TOKENS = [
+  'border-width-none',
+  'border-width-s',
+  'border-width-sm',
+  'border-width-m',
+  'border-width-l',
+  'border-width-xl',
+] as const;
+
+export type BoxBorderWidthToken = (typeof BOX_BORDER_WIDTH_TOKENS)[number];
+
+const BOX_BASE_STYLES = `.${BOX_CLASS_NAME} {\n  box-sizing: border-box;\n  min-width: 0;\n  min-height: 0;\n}`;
+
+let hasInjectedBoxStyles = false;
+
+export function ensureBoxStyles(): void {
+  if (hasInjectedBoxStyles || typeof document === 'undefined') {
+    return;
+  }
+
+  const existing = document.querySelector(`style[${BOX_STYLE_ATTRIBUTE}="true"]`);
+  if (existing) {
+    hasInjectedBoxStyles = true;
+    return;
+  }
+
+  const style = document.createElement('style');
+  style.setAttribute(BOX_STYLE_ATTRIBUTE, 'true');
+  style.textContent = BOX_BASE_STYLES;
+  document.head.appendChild(style);
+  hasInjectedBoxStyles = true;
+}
+
+export { BOX_STYLE_ATTRIBUTE, BOX_BASE_STYLES };

--- a/src/components/Box/index.ts
+++ b/src/components/Box/index.ts
@@ -1,0 +1,9 @@
+export { Box } from './Box';
+export type { BoxProps, BoxSpacingToken, BoxRadiusToken, BoxBorderWidthToken } from './Box';
+export {
+  BOX_CLASS_NAME,
+  BOX_SPACING_TOKENS,
+  BOX_RADIUS_TOKENS,
+  BOX_BORDER_WIDTH_TOKENS,
+  ensureBoxStyles,
+} from './box.styles';

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { Box } from "@components/Box";
 import { Button } from "@components/Button";
 import { Icon } from "@components/Icon";
 import {
@@ -136,14 +137,7 @@ export const Tertiary: Story = {
 
 export const DisabledStates: Story = {
   render: () => (
-    <div
-      style={{
-        display: "flex",
-        gap: "calc(var(--spacingL) * 1px)",
-        alignItems: "center",
-        flexWrap: "wrap",
-      }}
-    >
+    <Box display="flex" gap="spacing-l" alignItems="center" flexWrap="wrap">
       <Button variant="primary" disabled>
         Primary
       </Button>
@@ -153,7 +147,7 @@ export const DisabledStates: Story = {
       <Button variant="tertiary" disabled>
         Tertiary
       </Button>
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -168,19 +162,8 @@ export const DisabledStates: Story = {
 export const SemanticOverrides: Story = {
   name: "Semantic Overrides",
   render: () => (
-    <div
-      style={{
-        display: "grid",
-        gap: "calc(var(--spacingM) * 1px)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          gap: "calc(var(--spacingL) * 1px)",
-          flexWrap: "wrap",
-        }}
-      >
+    <Box display="grid" gap="spacing-m">
+      <Box display="flex" gap="spacing-l" flexWrap="wrap">
         {SEMANTIC_TONES.map((tone) => (
           <Button
             key={`primary-${tone}`}
@@ -190,14 +173,8 @@ export const SemanticOverrides: Story = {
             {tone} Primary
           </Button>
         ))}
-      </div>
-      <div
-        style={{
-          display: "flex",
-          gap: "calc(var(--spacingL) * 1px)",
-          flexWrap: "wrap",
-        }}
-      >
+      </Box>
+      <Box display="flex" gap="spacing-l" flexWrap="wrap">
         {SEMANTIC_TONES.map((tone) => (
           <Button
             key={`secondary-${tone}`}
@@ -207,14 +184,8 @@ export const SemanticOverrides: Story = {
             {tone} Secondary
           </Button>
         ))}
-      </div>
-      <div
-        style={{
-          display: "flex",
-          gap: "calc(var(--spacingL) * 1px)",
-          flexWrap: "wrap",
-        }}
-      >
+      </Box>
+      <Box display="flex" gap="spacing-l" flexWrap="wrap">
         {SEMANTIC_TONES.map((tone) => (
           <Button
             key={`tertiary-${tone}`}
@@ -224,8 +195,8 @@ export const SemanticOverrides: Story = {
             {tone} Tertiary
           </Button>
         ))}
-      </div>
-    </div>
+      </Box>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -258,14 +229,7 @@ export const Sizes: Story = {
     variant: "primary",
   },
   render: (args) => (
-    <div
-      style={{
-        display: "flex",
-        gap: "calc(var(--spacingL) * 1px)",
-        alignItems: "center",
-        flexWrap: "wrap",
-      }}
-    >
+    <Box display="flex" gap="spacing-l" alignItems="center" flexWrap="wrap">
       <Button {...args} size="sm">
         Small
       </Button>
@@ -275,7 +239,7 @@ export const Sizes: Story = {
       <Button {...args} size="lg">
         Large
       </Button>
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -294,9 +258,9 @@ export const FullWidth: Story = {
     variant: "primary",
   },
   render: (args) => (
-    <div style={{ width: 320 }}>
+    <Box width={320}>
       <Button {...args} />
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {

--- a/src/components/Icon/Icon.stories.tsx
+++ b/src/components/Icon/Icon.stories.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
+import { Box } from "@components/Box";
 import { Icon } from "@components";
 import { icons as ICONS } from "@shared/icons/icons.generated";
 
@@ -108,18 +109,12 @@ export const Sizes: Story = {
     color: "var(--textSecondaryInteractive)",
   },
   render: (args) => (
-    <div
-      style={{
-        display: "flex",
-        gap: "calc(var(--spacingL) * 1px)",
-        alignItems: "center",
-      }}
-    >
+    <Box display="flex" gap="spacing-l" alignItems="center">
       <Icon {...args} size="var(--iconsizesS)" />
       <Icon {...args} size="var(--iconsizesM)" />
       <Icon {...args} size="var(--iconsizesXl2)" />
       <Icon {...args} size="var(--iconsizesXl3)" />
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -138,36 +133,26 @@ export const TokenOverride: Story = {
     color: "var(--textPrimaryInteractive)",
   },
   render: (args) => (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        gap: "calc(var(--spacingM) * 1px)",
-      }}
-    >
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "calc(var(--spacingS) * 1px)",
-          "--icon-size": "var(--iconsizesL)",
-        } as React.CSSProperties}
+    <Box display="flex" flexDirection="column" gap="spacing-m">
+      <Box
+        display="flex"
+        alignItems="center"
+        gap="spacing-s"
+        style={{ "--icon-size": "var(--iconsizesL)" } as React.CSSProperties}
       >
         <span style={{ fontSize: "0.875rem" }}>Default token</span>
         <Icon {...args} size="var(--icon-size)" />
-      </div>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          gap: "calc(var(--spacingS) * 1px)",
-          "--icon-size": "48px",
-        } as React.CSSProperties}
+      </Box>
+      <Box
+        display="flex"
+        alignItems="center"
+        gap="spacing-s"
+        style={{ "--icon-size": "48px" } as React.CSSProperties}
       >
         <span style={{ fontSize: "0.875rem" }}>Overridden to 48px</span>
         <Icon {...args} size="var(--icon-size)" />
-      </div>
-    </div>
+      </Box>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -186,12 +171,12 @@ export const Colors: Story = {
     size: "var(--iconsizesXl2)",
   },
   render: (args) => (
-    <div style={{ display: "flex", gap: "calc(var(--spacingL) * 1px)" }}>
+    <Box display="flex" gap="spacing-l">
       <Icon {...args} color="var(--textPrimaryInteractive)" />
       <Icon {...args} color="var(--textPrimarySuccess)" />
       <Icon {...args} color="var(--textPrimaryWarning)" />
       <Icon {...args} color="var(--textPrimaryError)" />
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {

--- a/src/components/Typography/Typography.stories.tsx
+++ b/src/components/Typography/Typography.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
+import { Box } from '@components/Box';
 import { Typography } from '@components/Typography';
 import { TYPOGRAPHY_VARIANTS } from './typography.styles';
 
@@ -61,11 +62,11 @@ export const BodyCopy: Story = {
 
 export const Headings: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 'calc(var(--spacingM) * 1px)' }}>
+    <Box display="grid" gap="spacing-m">
       <Typography variant="heading-1">Heading 1</Typography>
       <Typography variant="heading-2">Heading 2</Typography>
       <Typography variant="heading-3">Heading 3</Typography>
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {
@@ -79,14 +80,14 @@ export const Headings: Story = {
 
 export const EmphasisAndLinks: Story = {
   render: () => (
-    <div style={{ display: 'grid', gap: 'calc(var(--spacingS) * 1px)' }}>
+    <Box display="grid" gap="spacing-s">
       <Typography variant="body-1-strong">Body 1 strong emphasizes supporting copy.</Typography>
       <Typography variant="body-2-strong">Body 2 strong with compact letter spacing.</Typography>
       <Typography variant="body-2-link" as="a" href="#">
         Body 2 link uses interactive tokens and can render as an anchor.
       </Typography>
       <Typography variant="caption-1">Caption 1 suits tertiary UI metadata.</Typography>
-    </div>
+    </Box>
   ),
   parameters: {
     docs: {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './Box';
 export * from './Button';
 export * from './Icon';
 export * from './Typography';


### PR DESCRIPTION
## Summary
- add a token-aware Box layout primitive with spacing shorthands, layout helpers, and shared style injection
- add Box stories, tests, documentation, and export wiring while updating existing stories to consume the primitive
- record governance updates and a changeset entry for the new component

## Testing
- yarn test
- yarn build
- VERIFY_AGENTS_BASE=$(git rev-list --max-parents=0 HEAD) yarn verify:agents

------
https://chatgpt.com/codex/tasks/task_e_68e2a6b4b098832c8fe5a9eeb7231f22